### PR TITLE
Added jupyter notebooks to the .gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 *.py[cod]
 
+# Notebook Examples (Must be Force Added)
+*.ipynb
+
 # C extensions
 *.so
 


### PR DESCRIPTION
Though these are useful for examples, during development it is often
undesireable to have all the changes get added to the full commit. In
order to add jupyter notebook examples (.ipynb files) to the repository,
add the files manually with the 'force' option specified.