### PR TITLE
Bugfix for remote fetch operations.

### DIFF
--- a/src/hangar/context.py
+++ b/src/hangar/context.py
@@ -114,8 +114,8 @@ class TxnRegister(metaclass=TxnRegisterSingleton):
         if ancestors == 0:
             msg = f'hash ancestors are zero but commit called on {lmdbenv}'
             err = RuntimeError(msg)
-            logger.error()
-            raise RuntimeError()
+            logger.error(msg)
+            raise err
         elif ancestors == 1:
             self.WriterTxn[lmdbenv].commit()
             self.WriterTxn.__delitem__(lmdbenv)


### PR DESCRIPTION
This fixes a nasty error where after the first batch fetch operation the
returned bytes were not properly packed and sent. A small sleep is
necessary between sending the last data chunk and the 'continuation'
context error so that the client can adequatly process all recieved
chunks before recieving the stopiteration error.