### PR TITLE
Allow single process access to multiple repos.

### DIFF
--- a/src/hangar/context.py
+++ b/src/hangar/context.py
@@ -175,9 +175,10 @@ from .records import commiting, heads
 class EnvironmentsSingleton(type):
     _instances = {}
     def __call__(cls, *args, **kwargs):
-        if cls not in cls._instances:
-            cls._instances[cls] = super(EnvironmentsSingleton, cls).__call__(*args, **kwargs)
-        return cls._instances[cls]
+        repo_path = kwargs['repo_path']
+        if repo_path not in cls._instances:
+            cls._instances[repo_path] = super(EnvironmentsSingleton, cls).__call__(*args, **kwargs)
+        return cls._instances[repo_path]
 
 
 class Environments(metaclass=EnvironmentsSingleton):

--- a/src/hangar/dataset.py
+++ b/src/hangar/dataset.py
@@ -79,7 +79,7 @@ class DatasetDataReader(object):
         self._index_expr_factory.maketuple = False
         self._schema_dtype_num = varDtypeNum
         self._mode = mode
-        self._fs = FileHandles()
+        self._fs = FileHandles(repo_path=repo_pth)
         self._Query = RecordQuery(self._dataenv)
         self._TxnRegister = TxnRegister()
 
@@ -925,7 +925,8 @@ class Datasets(object):
         STAGE_DATA_DIR = config.get('hangar.repository.stage_data_dir')
         stage_dir = os.path.join(self._repo_pth, STAGE_DATA_DIR, f'hdf_{schema_hash}')
         if not os.path.isdir(stage_dir):
-            f_handle = FileHandles().create_schema(self._repo_pth, schema_hash, prototype)
+            f_handle = FileHandles(repo_path=self._repo_pth).create_schema(
+                self._repo_pth, schema_hash, prototype)
             f_handle.close()
 
         # -------- set vals in lmdb only after schema is sure to exist --------

--- a/src/hangar/hdf5_store.py
+++ b/src/hangar/hdf5_store.py
@@ -16,11 +16,11 @@ logger = logging.getLogger(__name__)
 
 class FileHandlesSingleton(type):
     _instances = {}
-
     def __call__(cls, *args, **kwargs):
-        if cls not in cls._instances:
-            cls._instances[cls] = super(FileHandlesSingleton, cls).__call__(*args, **kwargs)
-        return cls._instances[cls]
+        repo_pth = kwargs['repo_path']
+        if repo_pth not in cls._instances:
+            cls._instances[repo_pth] = super(FileHandlesSingleton, cls).__call__(*args, **kwargs)
+        return cls._instances[repo_pth]
 
 
 '''
@@ -37,7 +37,8 @@ class FileHandles(metaclass=FileHandlesSingleton):
     write to the same dataset schema.
     '''
 
-    def __init__(self):
+    def __init__(self, repo_path):
+        self.repo_path = repo_path
         self.rHands = {}
         self.wHands = {}
         self.hMaxSize = {}

--- a/src/hangar/remote/hangar_client.py
+++ b/src/hangar/remote/hangar_client.py
@@ -50,7 +50,7 @@ class HangarClient(object):
                  auth_username: str = '', auth_password: str = ''):
 
         self.env = envs
-        self.fs = FileHandles()
+        self.fs = FileHandles(repo_path=self.env.repo_path)
         self.fs.open(self.env.repo_path, 'r')
 
         self.header_adder_int = header_adder_interceptor(auth_username, auth_password)

--- a/src/hangar/repository.py
+++ b/src/hangar/repository.py
@@ -13,7 +13,7 @@ from .context import Environments
 from .diagnostics import graphing
 from .records import heads, parsing, summarize, commiting
 from .remote.hangar_client import HangarClient
-
+from .utils import is_valid_directory_path
 
 logger = logging.getLogger(__name__)
 
@@ -35,9 +35,14 @@ class Repository(object):
     '''
 
     def __init__(self, path):
-        path = os.path.join(path, config.get('hangar.repository.hangar_dir_name'))
-        path = os.path.expanduser(path)
-        self._env = Environments(repo_path=path)
+
+        try:
+            usr_path = is_valid_directory_path(path)
+        except (TypeError, OSError, PermissionError) as e:
+            logger.error(e, exc_info=False)
+            raise
+        repo_pth = os.path.join(usr_path, config.get('hangar.repository.hangar_dir_name'))
+        self._env = Environments(repo_path=repo_pth)
         self._repo_path = self._env.repo_path
         self._client: Optional[HangarClient] = None
 

--- a/src/hangar/utils.py
+++ b/src/hangar/utils.py
@@ -133,6 +133,49 @@ def folder_size(repo_path, *, recurse_directories=False):
     return total
 
 
+def is_valid_directory_path(path: str) -> str:
+    '''Check if path is directory which user has write permission to.
+
+    Parameters
+    ----------
+    path : str
+        path to some location on disk
+
+    Returns
+    -------
+    str
+        If successful, the path with any user constructions expanded
+        (ie. `~/somedir` -> `/home/foo/somedir`)
+
+    Raises
+    ------
+    TypeError
+        If the provided path argument is not a pathlike object
+    OSError
+        If the path does not exist, or is not a directory on disk
+    PermissionError
+        If the user does not have write access to the specified path
+    '''
+    try:
+        usr_path = os.path.expanduser(path)
+        isDir = os.path.isdir(usr_path)
+        isWriteable = os.access(usr_path, os.W_OK)
+    except TypeError:
+        msg = f'HANGAR TYPE ERROR:: `path` arg: {path} of type: {type(path)} '\
+                f'is not valid path specifier'
+        raise TypeError(msg)
+
+    if not isDir:
+        msg = f'HANGAR VALUE ERROR:: `path` arg: {path} is not a directory.'
+        raise OSError(msg)
+    elif not isWriteable:
+        msg = f'HANGAR PERMISSION ERROR:: user does not have permission to write '\
+                f'to directory `path` arg: {path}'
+        raise PermissionError(msg)
+
+    return usr_path
+
+
 '''
 Methods following this notice have been taken & modified from the Dask Distributed project
 url: https://github.com/dask/distributed


### PR DESCRIPTION
Fix behavior which prevented a single python process from working on multiple repositories. 

## Description

These changes modify the behavior of the Environment and hdf5 FileHandler singleton classes to instantiate singleton instances based on the path of the checked out repository. This seems to fix all outstanding bugs related to these odd behaviors, but is untested as of yet.

The TransactionRegister singleton did not need to be updated because it the reference counting scheme is isolated for each lmdb environment which is passed to it. As different repository instances in the same process will now have unique lmdb environment handles, it does not require any modifications to it's current behavior.

## Motivation and Context
Addresses:
- https://github.com/tensorwerk/hangar-py/issues/4
- https://github.com/tensorwerk/hangar-py/issues/5

## How Has This Been Tested?
- local, and at head of #14 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.rst)** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

ping @hhsecond for sanity check. 