### PR TITLE
Quick Fix for variable name propagation issue in #31

### DIFF
--- a/src/hangar/dataset.py
+++ b/src/hangar/dataset.py
@@ -783,13 +783,13 @@ class Datasets(object):
                 self._datasets[dskey] = self._datasets[dskey].__enter__()
 
         try:
-            assert all([k in self._datasets for k in dset_data_map.keys()])
+            assert all([k in self._datasets for k in mapping.keys()])
             data_name = parsing.generate_sample_name()
-            for k, v in dset_data_map.items():
+            for k, v in mapping.items():
                 self._datasets[k].add(v, bulk_add_name=data_name)
 
         except AssertionError:
-            msg = f'HANGAR KEY ERROR:: one of keys: {dset_data_map.keys()} not in '\
+            msg = f'HANGAR KEY ERROR:: one of keys: {mapping.keys()} not in '\
                   f'datasets: {self._datasets.keys()}'
             logger.error(msg)
             raise KeyError(msg)


### PR DESCRIPTION
## Description
Change of variable name in [here](https://github.com/tensorwerk/hangar-py/blob/044937c5a00fa48bd2889cce878648404645591d/src/hangar/dataset.py#L743) did not go throughout the function and we are using the old name

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.rst)** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
