### PR TITLE
Invalidate existing dataset or metadata accessor objects after a checkout is closed

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ addopts =
     --ignore=.eggs
     # --doctest-modules
     # --doctest-glob=\*.rst
-    --tb=short
+    --tb=auto
 
 [isort]
 force_single_line = True

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
         'grpcio',
         'grpcio_tools',
         'tqdm',
+        'wrapt',
     ],
     extras_require={},
     entry_points={

--- a/src/hangar/checkout.py
+++ b/src/hangar/checkout.py
@@ -1,7 +1,6 @@
 import logging
 from os.path import join as pjoin
 from uuid import uuid4
-import gc
 
 from . import config
 from .dataset import Datasets
@@ -144,7 +143,6 @@ class ReaderCheckout(object):
             dsetHandle._close()
         del self._datasets
         del self._metadata
-        gc.collect()
 
 
 # --------------- Write enabled checkout ---------------------------------------
@@ -280,7 +278,6 @@ class WriterCheckout(object):
             try:
                 del self._datasets
                 del self._metadata
-                gc.collect()
             except AttributeError:
                 pass
             err = f'Unable to operate on past checkout objects which have been '\
@@ -294,7 +291,6 @@ class WriterCheckout(object):
             try:
                 del self._datasets
                 del self._metadata
-                gc.collect()
             except AttributeError:
                 pass
             logger.error(e, exc_info=0)
@@ -455,5 +451,4 @@ class WriterCheckout(object):
         del self._datasets
         del self._metadata
         del self._writer_lock
-        gc.collect()
         logger.info(f'writer checkout of {self._branch_name} closed')

--- a/src/hangar/checkout.py
+++ b/src/hangar/checkout.py
@@ -1,7 +1,6 @@
 import logging
 from os.path import join as pjoin
 from uuid import uuid4
-import weakref
 import gc
 
 from . import config
@@ -12,6 +11,7 @@ from .metadata import MetadataWriter
 from .records import commiting
 from .records import hashs
 from .records import heads
+from .utils import cm_weakref_obj_proxy
 
 logger = logging.getLogger(__name__)
 
@@ -101,7 +101,7 @@ class ReaderCheckout(object):
             lock is released.
         '''
         self.__verify_checkout_alive()
-        wr = weakref.proxy(self._datasets)
+        wr = cm_weakref_obj_proxy(self._datasets)
         return wr
 
     @property
@@ -116,7 +116,7 @@ class ReaderCheckout(object):
             released.
         '''
         self.__verify_checkout_alive()
-        wr = weakref.proxy(self._metadata)
+        wr = cm_weakref_obj_proxy(self._metadata)
         return wr
 
     @property
@@ -241,7 +241,7 @@ class WriterCheckout(object):
             lock is released.
         '''
         self.__acquire_writer_lock()
-        wr = weakref.proxy(self._datasets)
+        wr = cm_weakref_obj_proxy(self._datasets)
         return wr
 
     @property
@@ -256,7 +256,7 @@ class WriterCheckout(object):
             released.
         '''
         self.__acquire_writer_lock()
-        wr = weakref.proxy(self._metadata)
+        wr = cm_weakref_obj_proxy(self._metadata)
         return wr
 
     @property

--- a/src/hangar/dataset.py
+++ b/src/hangar/dataset.py
@@ -3,6 +3,8 @@ import os
 from typing import Optional
 from uuid import uuid1
 import logging
+import weakref
+import gc
 
 import numpy as np
 import lmdb
@@ -720,7 +722,8 @@ class Datasets(object):
             If no dataset with the given name exists in the checkout
         '''
         try:
-            return self._datasets[name]
+            wr = weakref.proxy(self._datasets[name])
+            return wr
         except KeyError:
             msg = f'HANGAR KEY ERROR:: No dataset exists with name: {name}'
             e = KeyError(msg)
@@ -995,7 +998,7 @@ class Datasets(object):
             mode='a')
 
         logger.info(f'Dataset Initialized: `{name}`')
-        return self._datasets[name]
+        return self.get(name)
 
     def remove_dset(self, dset_name):
         '''remove the dataset and all data contained within it from the repository.

--- a/src/hangar/dataset.py
+++ b/src/hangar/dataset.py
@@ -3,8 +3,6 @@ import os
 from typing import Optional
 from uuid import uuid1
 import logging
-import weakref
-import gc
 
 import numpy as np
 import lmdb
@@ -14,7 +12,7 @@ from .context import TxnRegister
 from .hdf5_store import FileHandles
 from .records import parsing
 from .records.queries import RecordQuery
-from .utils import is_ascii_alnum
+from .utils import is_ascii_alnum, cm_weakref_obj_proxy
 
 logger = logging.getLogger(__name__)
 
@@ -689,7 +687,7 @@ class Datasets(object):
             as appropriate)
         '''
         for dsetObj in self._datasets.values():
-            wr = weakref.proxy(dsetObj)
+            wr = cm_weakref_obj_proxy(dsetObj)
             yield wr
 
     def items(self):
@@ -702,7 +700,7 @@ class Datasets(object):
 
         '''
         for dsetN, dsetObj in self._datasets.items():
-            wr = weakref.proxy(dsetObj)
+            wr = cm_weakref_obj_proxy(dsetObj)
             yield (dsetN, wr)
 
     def get(self, name):
@@ -717,8 +715,8 @@ class Datasets(object):
 
         Returns
         -------
-        object
-            DatasetData accessor (set to read or write mode as appropriate)
+        ObjectProxy
+            DatasetData accessor (set to read or write mode as appropriate) proxy
 
         Raises
         ------
@@ -726,7 +724,7 @@ class Datasets(object):
             If no dataset with the given name exists in the checkout
         '''
         try:
-            wr = weakref.proxy(self._datasets[name])
+            wr = cm_weakref_obj_proxy(self._datasets[name])
             return wr
         except KeyError:
             msg = f'HANGAR KEY ERROR:: No dataset exists with name: {name}'

--- a/src/hangar/dataset.py
+++ b/src/hangar/dataset.py
@@ -682,12 +682,15 @@ class Datasets(object):
     def values(self):
         '''list all dataset object instances in the checkout
 
-        Returns
+        Yields
         -------
-        list of obj
-            list of dataset objects used to interact with the data
+        object
+            Generator of DatasetData accessor objects (set to read or write mode
+            as appropriate)
         '''
-        return self._datasets.values()
+        for dsetObj in self._datasets.values():
+            wr = weakref.proxy(dsetObj)
+            yield wr
 
     def items(self):
         '''generator providing access to dataset_name, :class:``Datasets``
@@ -699,7 +702,8 @@ class Datasets(object):
 
         '''
         for dsetN, dsetObj in self._datasets.items():
-            yield (dsetN, dsetObj)
+            wr = weakref.proxy(dsetObj)
+            yield (dsetN, wr)
 
     def get(self, name):
         '''Returns a dataset access object.

--- a/src/hangar/metadata.py
+++ b/src/hangar/metadata.py
@@ -67,12 +67,15 @@ class MetadataReader(object):
         else:
             return False
 
+    def __len__(self):
+        return len(self._Query.metadata_names())
+
     def __iter__(self):
-        raise NotImplementedError()
+        return self.keys()
 
     def __repr__(self):
         res = f'\n Hangar Metadata\
-                \n     Number of Keys : {len(self._Query.metadata_names())}\
+                \n     Number of Keys : {len(self)}\
                 \n     Access Mode    : r\n'
         return res
 
@@ -194,7 +197,7 @@ class MetadataWriter(MetadataReader):
 
     def __repr__(self):
         res = f'\n Hangar Metadata\
-                \n     Number of Keys : {len(self._Query.metadata_names())}\
+                \n     Number of Keys : {len(self)}\
                 \n     Access Mode    : a\n'
         return res
 

--- a/src/hangar/records/heads.py
+++ b/src/hangar/records/heads.py
@@ -73,8 +73,8 @@ def acquire_writer_lock(branchenv, writer_uuid):
 
     Raises
     ------
-    RuntimeError
-        If the lock can not be acquired, runtime error is thrown
+    PermissionError
+        If the lock can not be acquired
 
     '''
     writerLockKey = parsing.repo_writer_lock_db_key()

--- a/src/hangar/repository.py
+++ b/src/hangar/repository.py
@@ -1,5 +1,4 @@
 import os
-from typing import Optional
 import logging
 from . import config_logging
 config_logging.setup_logging()
@@ -44,7 +43,7 @@ class Repository(object):
         repo_pth = os.path.join(usr_path, config.get('hangar.repository.hangar_dir_name'))
         self._env = Environments(repo_path=repo_pth)
         self._repo_path = self._env.repo_path
-        self._client: Optional[HangarClient] = None
+        self._client: HangarClient = None
 
     def _repr_pretty_(self, p, cycle):
         '''provide a pretty-printed repr for ipython based user interaction.
@@ -459,7 +458,13 @@ class Repository(object):
         return pth
 
     def log(self, branch_name=None, commit_hash=None, *, return_contents=False):
-        '''Alias for lmdb_utils.list_history() call
+        '''Displays a pretty printed commit log graph to the terminal.
+
+        .. note::
+
+            For programatic access, the return_contents value can be set to true
+            which will retrieve relevant commit specifications as dictionary
+            elements.
 
         Parameters
         ----------
@@ -468,6 +473,9 @@ class Repository(object):
             = None)
         commit_hash : str
             The commit hash to start the log process from. (Default value = None)
+        return_contents : bool, optional, kwarg only
+            If true, return the commit graph specifications in a dictionary
+            suitable for programatic access/evalutation.
 
         Returns
         -------
@@ -491,7 +499,11 @@ class Repository(object):
                 order=res['order'])
 
     def summary(self, *, branch_name='', commit='', return_contents=False):
-        '''Alias for lmdb_utils.summary() call
+        '''Print a summary of the repository contents to the terminal
+
+        .. note::
+
+            Programatic access is provided by the return_contents argument.
 
         Parameters
         ----------

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -62,6 +62,31 @@ class TestCheckout(object):
         with pytest.raises(ReferenceError):
             dset.__dict__
 
+    def test_writer_dset_obj_dataset_iter_values_not_accessible_after_close(self, written_repo):
+        repo = written_repo
+        co = repo.checkout(write=True)
+        oldObjs = []
+        for oldObj in co.datasets.values():
+            oldObjs.append(oldObj)
+        co.close()
+
+        for oldObj in oldObjs:
+            with pytest.raises(ReferenceError):
+                oldObj.__dict__
+
+    def test_writer_dset_obj_dataset_iter_items_not_accessible_after_close(self, written_repo):
+        repo = written_repo
+        co = repo.checkout(write=True)
+        oldObjs = {}
+        for oldName, oldObj in co.datasets.items():
+            oldObjs[oldName] = oldObj
+        co.close()
+
+        for name, obj in oldObjs.items():
+            assert isinstance(name, str)
+            with pytest.raises(ReferenceError):
+                obj.__dict__
+
     def test_writer_dset_obj_not_accessible_after_commit_and_close(self, written_repo, array5by7):
         repo = written_repo
         co = repo.checkout(write=True)
@@ -93,6 +118,31 @@ class TestCheckout(object):
             shouldFail = dsets['_dset']
         with pytest.raises(ReferenceError):
             dset.__dict__
+
+    def test_reader_dset_obj_dataset_iter_values_not_accessible_after_close(self, written_repo):
+        repo = written_repo
+        co = repo.checkout(write=False)
+        oldObjs = []
+        for oldObj in co.datasets.values():
+            oldObjs.append(oldObj)
+        co.close()
+
+        for oldObj in oldObjs:
+            with pytest.raises(ReferenceError):
+                oldObj.__dict__
+
+    def test_reader_dset_obj_dataset_iter_items_not_accessible_after_close(self, written_repo):
+        repo = written_repo
+        co = repo.checkout(write=False)
+        oldObjs = {}
+        for oldName, oldObj in co.datasets.items():
+            oldObjs[oldName] = oldObj
+        co.close()
+
+        for name, obj in oldObjs.items():
+            assert isinstance(name, str)
+            with pytest.raises(ReferenceError):
+                obj.__dict__
 
     def test_writer_metadata_obj_not_accessible_after_close(self, written_repo):
         repo = written_repo

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -23,6 +23,10 @@ class TestDataset(object):
 
         # getting the dataset with `get`
         dsetOld = co.datasets.get('_dset')
+        dsetOldPath = dsetOld._path
+        dsetOldDsetn = dsetOld._dsetn
+        dsetOldDefaultSchemaHash = dsetOld._default_schema_hash
+        dsetOldSchemaUUID = dsetOld._schema_uuid
 
         dsetOld.add(array5by7, '1')
         co.commit()
@@ -33,10 +37,10 @@ class TestDataset(object):
         dsetNew = co.datasets['_dset']
 
         assert np.allclose(dsetNew['1'], array5by7)
-        assert dsetOld._path == dsetNew._path
-        assert dsetOld._dsetn == dsetNew._dsetn
-        assert dsetOld._default_schema_hash == dsetNew._default_schema_hash
-        assert dsetOld._schema_uuid == dsetNew._schema_uuid
+        assert dsetOldPath == dsetNew._path
+        assert dsetOldDsetn == dsetNew._dsetn
+        assert dsetOldDefaultSchemaHash == dsetNew._default_schema_hash
+        assert dsetOldSchemaUUID == dsetNew._schema_uuid
 
     def test_remove_dataset(self, written_repo):
         co = written_repo.checkout(write=True)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -63,9 +63,8 @@ class TestMetadata(object):
             assert v == f'v_{i}'
         for i, k in enumerate(co.metadata.keys()):
             assert co.metadata[k] == f'v_{i}'
-        with pytest.raises(NotImplementedError):
-            for i, k in enumerate(co.metadata):
-                assert co.metadata[k] == f'v_{i}'
+        for i, k in enumerate(co.metadata):
+            assert co.metadata[k] == f'v_{i}'
         for i, v in enumerate(co.metadata.values()):
             assert co.metadata[f'k_{i}'] == v
         for i in range(limit):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

These changes ensure that when a checkout (reader or writer) is closed, that any references to `dataset` or `metadata` objects are invalidated and will not perform any type of operation. 

## Description

Instead of explicitly validating that some sort of `IS_ALIVE` sentinal on every call to the `dataset` or `metadata` interactor objects, we  use an invalidation scheme based on weakrefs. The control flow is as follows: 

1) A strong reference to a dataset or metadata instance is created and held in a "`_private`" attribute of the `checkout` class. In the new scheme, this is the ONLY strong reference which will be kept to the members. 

2) For public consumption, `datasets` and `metadata` methods are defined in the `checkout` object using the `property` protocol to remap the `getter` to the internal attributes. Because no `setter` is defined, these properties cannot be changed by the user.

3) At this point, we do a "bait-and-switch", providing a `weakref proxy` to the requested object. By definition, these do not increment the reference count, but pass through all calls to the checkout's instance of the actual object.

4) when the `checkout.close()` method is called, the checkout objects `._datasets` and `._metadata` attributes are deleted and we explicitly perform a garbage collection.

5) Since `weakrefs` don't increment reference counts, when the attributes are deleted on close and gc is run, the `proxy` mapping no longer has a valid reference. It will raise a `ReferenceError()` if any operation is attempted on it. 

6) Validations performed in the `checkout` class ensure that the object is essentially dead to the user, and a new checkout must be created to interact with the repository again. 

This is a performant and clean way of ensuring that users are not able to perform operations during a time they shouldn't be able to. Methods are implemented for both read and write checkouts and both function as expected and pass all tests. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Examples of the problem before this fix were first shown in Issue #36. Please refer to that posting for further background. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Test cases have been added to the test suite.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.rst)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


Please review @hhsecond and @lantiga 
