### PR TITLE
Quick fix for substring check

### DIFF
--- a/src/hangar/records/queries.py
+++ b/src/hangar/records/queries.py
@@ -2,6 +2,8 @@ from . import parsing
 from .. import config
 from ..context import TxnRegister
 
+SEP = config.get('hangar.seps.key')
+
 
 '''
 Data record queries
@@ -110,10 +112,11 @@ class RecordQuery(object):
             with datatxn.cursor() as cursor:
                 # with datatxn.cursor() as cursor:
                 dataRecordsExist = cursor.set_range(startDatasetRecordCountRangeKey)
+                dataRecKeySubString = f'{startDatasetRecordCountRangeKey.decode()}{SEP}'.encode()
                 cursor.next()
                 while dataRecordsExist:
                     dataRecKey, dataRecVal = cursor.item()
-                    if dataRecKey.startswith(startDatasetRecordCountRangeKey):
+                    if dataRecKey.startswith(dataRecKeySubString):
                         data_records[dataRecKey] = dataRecVal
                         dataRecordsExist = cursor.next()
                         continue


### PR DESCRIPTION
## Motivation and Context
Quick fix for substring check to fix #49 

## Description
Substring check for dataset name dataset traversal now checks for a substring that ends with `:` which prevents from accidentally including other datasets that have the same name in the start of the datasets name
eg: 
`MNIST` and `MNISTLabel`

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Is this PR ready for review, or a work in progress?
- [x] Ready for review
- [ ] Work in progress

## How Has This Been Tested?
Put an `x` in the boxes that apply:
- [x] Current tests cover modifications made
- [ ] New tests have been added to the test suite
- [ ] Modifications were made to existing tests to support these changes
- [ ] Tests may be needed, but they are not included when the PR was proposed
- [ ] I don't know. Help!

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.rst)** document.
- [x] I have signed (or will sign when prompted) the tensorwork CLA.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
