### PR TITLE
Fix invalidate obj on close

### DIFF
--- a/src/hangar/metadata.py
+++ b/src/hangar/metadata.py
@@ -82,6 +82,9 @@ class MetadataReader(object):
                 \n     Access Mode    : r\n'
         return res
 
+    def __len__(self):
+        return len(self._Query.metadata_names())
+
     @property
     def iswriteable(self):
         '''Bool indicating if this metadata object is write-enabled. Read-only attribute.

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -358,7 +358,7 @@ class TestDataWithFixedSizedDataset(object):
             # raises before commit
             dset['1'] = array5by7
         co.commit()
-        with pytest.raises(ReferenceError):
+        with pytest.raises(LookupError):
             # raises after commit
             dset['1'] = array5by7
         co.close()


### PR DESCRIPTION
## Motivation and Context
Why is this change required? What problem does it solve?:

A full overview of the problem is provided in: https://github.com/tensorwerk/hangar-py/issues/53#issue-445384574. However, in brief:

- the changes introduced in #41 resulted in a few situations where when a `write-enabled checkout` (and only `write-enabled`) would inadvertently invalidate the old `weakproxy` references which had been assigned to it, before the `checkout.close()` method was formally called. 
- This was observed to occur when `checkout.commit()` and `checkout.reset_staging_area()` were called. 
- The reason was because these two functions made calls into `checkout.__setup()`, replaced the only strong references to previously `"proxied"` `dataset` or `metadata` objects with new versions. 

If it fixes an open issue, please link to the issue here:
- #53

## Description
Describe your changes in detail:

- In order to stick with the idea that `"__setup"` should probably only be called *once* upon actual class "setup"..., the problem calls were just wholesale removed from `commit()` and `reset_stating_area()`. 
- For `commit()`, we actually do need to perform some setup work for the backend file-stores (mainly to open and close file handles so symlinks can be properly identified). This work was pushed into the `DatasetDataWriter` class which actually performed that work natively, and this is arguably cleaner than the previous implementation. No changes were needed for `metadata` if we don't try to rebuild the entire object, it just works :)
- For `reset_staging_area()`, I thought the best choice would be to just have that operation close the checkout in full just before it `returns`. It's probably best for a user to fully reset their environment after wiping out the staging area in full, and that is the most effective way to ensure no leftover state is hanging around after this is called. 

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Is this PR ready for review, or a work in progress?
- [x] Ready for review
- [ ] Work in progress

## How Has This Been Tested?
Put an `x` in the boxes that apply:
- [x] Current tests cover modifications made
- [x] New tests have been added to the test suite
- [x] Modifications were made to existing tests to support these changes
- [ ] Tests may be needed, but they are not included when the PR was proposed
- [ ] I don't know. Help!

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.rst)** document.
- [x] I have signed (or will sign when prompted) the tensorwork CLA.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
