### PR TITLE
Explicit verification of `write` argument

### DIFF
--- a/src/hangar/repository.py
+++ b/src/hangar/repository.py
@@ -142,6 +142,11 @@ class Repository(object):
             name parameter if it is set. Note: this only will be used in
             non-writeable checkouts, defaults to ''
 
+        Raises
+        ------
+        ValueError
+            If the value of `write` argument is not boolean
+
         Returns
         -------
         object
@@ -161,7 +166,7 @@ class Repository(object):
                     branchenv=self._env.branchenv,
                     stagehashenv=self._env.stagehashenv)
                 return co
-            else:
+            elif write is False:
                 commit_hash = self._env.checkout_commit(
                     branch_name=branch_name, commit=commit)
 
@@ -174,6 +179,8 @@ class Repository(object):
                     refenv=self._env.refenv,
                     commit=commit_hash)
                 return co
+            else:
+                raise ValueError("Argument `write` only takes True or False as value")
         except (RuntimeError, ValueError) as e:
             logger.error(e, exc_info=False, extra=self._env.__dict__)
             raise e from None

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -291,6 +291,17 @@ class TestCheckout(object):
         with pytest.raises(ReferenceError):
             dset2.name
 
+    def test_with_wrong_argument_value(self, repo):
+        # It is intuitive to a user to pass branchname as positional
+        # argument but hangar expect permission as first argument
+        with pytest.raises(ValueError):
+            repo.checkout('branchname')
+        with pytest.raises(ValueError):
+            repo.checkout(write='True')
+        with pytest.raises(ValueError):
+            repo.checkout(branch_name=True)
+        repo.checkout(True)  # This should not raise any excpetion
+
 
 class TestBranching(object):
 
@@ -426,8 +437,3 @@ class TestBranching(object):
         assert h2['head'] == h3['head']
         assert h2['ancestors'][h2['head']] == h3['ancestors'][h3['head']]
         assert h1['head'] in h2['ancestors'][h2['head']]
-
-
-@pytest.mark.skip(reason='not implemented')
-class TestTimeTravel(object):
-    pass


### PR DESCRIPTION
## Motivation and Context
From a UX perspective, a user is tend to pass `branch_name` as positional argument to `checkout()`. Currently, `repo.checkout('branchname')` doesn't throw any error but takes the value `branchname` as value of `write` and falls to the `else` condition check inside the function. This creates subtle situations. An appropriate solution would be to make `branch_name` / `commit_hash` as the first argument but this might not be the usage that happens often. So for now, we can go with the check this PR introduces which is the check for the value of `write` explicitly.

## Description
Checking the value of `write` explicitly on `repo.checkout`

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Is this PR ready for review, or a work in progress?
- [x] Ready for review
- [ ] Work in progress

## How Has This Been Tested?
Put an `x` in the boxes that apply:
- [x] Current tests cover modifications made
- [x] New tests have been added to the test suite
- [ ] Modifications were made to existing tests to support these changes
- [ ] Tests may be needed, but they are not included when the PR was proposed
- [ ] I don't know. Help!

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.rst)** document.
- [x] I have signed (or will sign when prompted) the tensorwork CLA.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
