### PR TITLE
multithread / multiprocess safe dataset reads

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Improvements
 
 * Record format versioning and standardization so to not break backwards compatibility in the future. (`#70 <https://github.com/tensorwerk/hangar-py/pull/70>`__) `@rlizzo <https://github.com/rlizzo>`__
 * Backend addition and update developer protocols and documentation. (`#70 <https://github.com/tensorwerk/hangar-py/pull/70>`__) `@rlizzo <https://github.com/rlizzo>`__
+* Read-only checkout dataset sample ``get`` methods now are multithread and multiprocess safe. (`#84 <https://github.com/tensorwerk/hangar-py/pull/84>`__) `@rlizzo <https://github.com/rlizzo>`__
 * Many tests added (including support for Mac OSX on Travis-CI).
 
 Bug Fixes

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ setup(
         'pyyaml',
         'tqdm',
         'wrapt',
-        'joblib',
     ],
     extras_require={},
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
         'pyyaml',
         'tqdm',
         'wrapt',
+        'joblib',
     ],
     extras_require={},
     entry_points={

--- a/src/hangar/backends/hdf5.py
+++ b/src/hangar/backends/hdf5.py
@@ -261,10 +261,10 @@ class HDF5_00_FileHandles(object):
     def __getstate__(self):
         '''ensure multiprocess operations can pickle relevant data. need tests'''
         self.close()
-        time.sleep(0.05)  # buffer time
+        time.sleep(0.1)  # buffer time
         state = self.__dict__.copy()
-        state['rFp'] = {}
-        state['wFp'] = {}
+        del state['rFp']
+        del state['wFp']
         del state['Fp']
         del state['fmtParser']
         return state
@@ -272,6 +272,8 @@ class HDF5_00_FileHandles(object):
     def __setstate__(self, state):
         '''ensure multiprocess operations can pickle relevant data. need tests'''
         self.__dict__.update(state)
+        self.rFp = {}
+        self.wFp = {}
         self.Fp = ChainMap(self.rFp, self.wFp)
         self.fmtParser = HDF5_00_Parser()
         self.open(self.mode)

--- a/src/hangar/backends/remote_unknown.py
+++ b/src/hangar/backends/remote_unknown.py
@@ -7,15 +7,15 @@ import numpy as np
 logger = logging.getLogger(__name__)
 
 
+DataHashSpec = namedtuple('DataHashSpec', field_names=['backend'])
+
+
 class REMOTE_UNKNOWN_00_Parser(object):
 
-    __slots__ = ['FmtCode', 'RemoteHashSpec']
+    __slots__ = ['FmtCode']
 
     def __init__(self):
-
         self.FmtCode = '50'
-        RemoteHashSpec = namedtuple('DataHashSpec', field_names=['backend'])
-        self.RemoteHashSpec = RemoteHashSpec(backend=self.FmtCode)
 
     def encode(self) -> bytes:
         '''returns an db value saying that this hash exists somewhere on a remote
@@ -40,7 +40,7 @@ class REMOTE_UNKNOWN_00_Parser(object):
         namedtuple
             hash specification containing an identifies: `backend`
         '''
-        return self.RemoteHashSpec
+        return DataHashSpec(self.FmtCode)
 
 
 class REMOTE_UNKNOWN_00_Handler(object):
@@ -49,7 +49,6 @@ class REMOTE_UNKNOWN_00_Handler(object):
         self.repo_path = repo_path
         self.schema_shape = schema_shape
         self.schema_dtype = schema_dtype
-
         self.fmtParser = REMOTE_UNKNOWN_00_Parser()
 
     def __enter__(self):

--- a/src/hangar/backends/selection.py
+++ b/src/hangar/backends/selection.py
@@ -4,7 +4,7 @@ This module defines the available backends for a Hangar installation & provides
 dynamic routing of method calls to the appropriate backend from a stored record
 specification.
 
-Identifiation
+Identification
 -------------
 
 A two character ascii code identifies which backend some record belongs to.
@@ -17,31 +17,31 @@ Though stored as bytes in the backend, we use human readable characters (and not
 unprintable bytes) to aid in human tasks like developer database dumps and
 debugging
 
-The number of codes possible (a 2-choice permutaion with repetion) is: 3844
+The number of codes possible (a 2-choice permutation with repetition) is: 3844
 which we anticipate to be more then sufficient long into the future. As a
 convention, the first digit of the code can be used to identify the storage
 medium:
 
     * Lowercase ascii letters & digits [0, 1, 2, 3, 4] -> reserved for
-      backends handeling data on the local disk.
+      backends handling data on the local disk.
     * Uppercase ascii letters & digits [5, 6, 7, 8, 9] -> reserved for
-      backends refereing to data residing on a remote server.
+      backends referring to data residing on a remote server.
 
 This is not a hard and fast rule though, and can be changed in the future if the
 need arises.
 
-Process & Guarrentees
+Process & Guarantees
 ---------------------
 
 In order to maintain backwards compatibility across versions of Hangar into the
 future the following ruleset is specified and MUST BE HONORED:
 
     * When a new backend is proposed, the contributor(s) provide the class with a
-      cannonical name (HDF5_00, TILEDB_01, etc) for developer consumption in the
+      canonical name (HDF5_00, TILEDB_01, etc) for developer consumption in the
       backend. The review team will provide an available two-digit code which all
       records corresponding to that backend must identify themselves with.
 
-    * Once a new backend is accepted, the code assigned to it is PERMENANT &
+    * Once a new backend is accepted, the code assigned to it is PERMANENT &
       UNCHANGING. The same code cannot be used in the future for other backends.
 
     * Each backend independently determines the information it needs to log/store to
@@ -53,14 +53,14 @@ future the following ruleset is specified and MUST BE HONORED:
       storage request for some piece of data is performed.
 
     * Once accepted, The record format specified (ie. the byte representation
-     described above) cannot be modified in any way. This must remain permenant!
+     described above) cannot be modified in any way. This must remain permanent!
 
     * Backend (internal) methods can be updated, optimized, and/or changed at any
      time so long as:
 
         * No changes to the record format specification are introduced
         * Data stored via any previous iteration of the backend's accessor methods
-          can be retrieved bitwise exactally by the "updated" version.
+          can be retrieved bitwise exactly by the "updated" version.
 
 Before proposing a new backend or making changes to this file, please consider
 reaching out to the Hangar core development team so we can guide you through the

--- a/src/hangar/dataset.py
+++ b/src/hangar/dataset.py
@@ -2,6 +2,7 @@ import hashlib
 import logging
 from typing import Optional
 from multiprocessing import Pool, get_context, cpu_count
+from typing import MutableMapping
 
 import lmdb
 import numpy as np
@@ -248,10 +249,10 @@ class DatasetDataReader(object):
 
         The method is thread/process safe IF used in a read only checkout. Use
         this if the calling application wants to manually manage multiprocess
-        logic for data retrieval. Otherwise, hangar includes the ``batch_get``
-        method to retrieve multiple data samples simultaneously. This method
-        uses multiprocess pool of workers (managed by hangar) to drastically
-        increase access speed and simplifly application developer workflows.
+        logic for data retrieval. Otherwise, see the :py:meth:`get_batch` method
+        to retrieve multiple data samples simultaneously. This method uses
+        multiprocess pool of workers (managed by hangar) to drastically increase
+        access speed and simplify application developer workflows.
 
         .. note::
 
@@ -291,7 +292,7 @@ class DatasetDataReader(object):
         method has been seen to drastically decrease retrieval time of sample
         batches (as compared to looping over single sample names sequentially).
         Internally it implements a multiprocess pool of workers (managed by
-        hangar) to simplifly application developer workflows.
+        hangar) to simplify application developer workflows.
 
         Parameters
         ----------
@@ -311,7 +312,7 @@ class DatasetDataReader(object):
         list(np.ndarray)
             Tensor data stored in the dataset archived with provided name(s).
 
-            If a single sample name is passed in as th, the corresponding
+            If a single sample name is passed in as the, the corresponding
             np.array data will be returned.
 
             If a list/tuple of sample names are pass in the ``names`` argument,
@@ -333,14 +334,18 @@ class DatasetDataReader(object):
 class DatasetDataWriter(DatasetDataReader):
     '''Class implementing methods to write data to a dataset.
 
-    Extends the functionality of the DatasetDataReader class. The __init__ method requires
-    quite a number of ``**kwargs`` to be passed along to the :class:`DatasetDataReader`
-    class.
+    Extends the functionality of the DatasetDataReader class. The __init__
+    method requires quite a number of ``**kwargs`` to be passed along to the
+    :class:`DatasetDataReader` class.
 
     .. seealso:: :class:`DatasetDataReader`
 
     Parameters
     ----------
+        stagehashenv : lmdb.Environment
+            db where the newly added staged hash data records are stored
+        default_schema_backend : str
+            backend code to act as default where new data samples are added.
         **kwargs:
             See args of :class:`DatasetDataReader`
     '''
@@ -377,7 +382,7 @@ class DatasetDataWriter(DatasetDataReader):
             self._fs[k].__exit__(*exc)
 
     def __setitem__(self, key, value):
-        '''Store a piece of data in a dataset. Convenince method to :meth:`add`.
+        '''Store a piece of data in a dataset. Convenience method to :meth:`add`.
 
         .. seealso:: :meth:`add`
 
@@ -397,7 +402,7 @@ class DatasetDataWriter(DatasetDataReader):
         return key
 
     def __delitem__(self, key):
-        '''Remove a sample from the dataset. Convenence method to :meth:`remove`.
+        '''Remove a sample from the dataset. Convenience method to :meth:`remove`.
 
         .. seealso:: :meth:`remove`
 
@@ -450,14 +455,14 @@ class DatasetDataWriter(DatasetDataReader):
             For variable shape datasets, if a dimension size of the input data
             tensor exceeds specified max dimension size of the dataset samples.
         ValueError
-            For fixed shape datasets, if input data dimensions do not exactally match
+            For fixed shape datasets, if input data dimensions do not exactly match
             specified dataset dimensions.
         ValueError
             If type of `data` argument is not an instance of np.ndarray.
         ValueError
             If `data` is not "C" contiguous array layout.
         ValueError
-            If the datatype of the input data does not match the specifed data type of
+            If the datatype of the input data does not match the specified data type of
             the dataset
         LookupError
             If a data sample with the same name and hash value already exists in the
@@ -558,7 +563,7 @@ class DatasetDataWriter(DatasetDataReader):
 
             This operation will NEVER actually remove any data from disk. If
             you commit a tensor at any point in time, **it will always remain
-            accessable by checking out a previous commit** when the tensor was
+            accessible by checking out a previous commit** when the tensor was
             present. This is just a way to tell Hangar that you don't want some
             piece of data to clutter up the current version of the repository.
 
@@ -569,7 +574,7 @@ class DatasetDataWriter(DatasetDataReader):
             staging area, written to disk, but then removed **before** a commit
             operation was run. This would be a similar sequence of events as:
             checking out a `git` branch, changing a bunch of text in the file, and
-            immediatly performing a hard reset. If it was never committed, git
+            immediately performing a hard reset. If it was never committed, git
             doesn't know about it, and (at the moment) neither does Hangar.
 
         Parameters
@@ -639,13 +644,13 @@ Constructor and Interaction Class for Datasets
 
 
 class Datasets(object):
-    '''Common access patterns and initilization/removal of datasets in a checkout.
+    '''Common access patterns and initialization/removal of datasets in a checkout.
 
     .. warning::
 
         This class should not be instantiated directly. Instead use the factory
         functions :py:meth:`_from_commit` or :py:meth:`_from_staging` to
-        return a pre-initialized class instance appropriatly constructed for
+        return a pre-initialized class instance appropriately constructed for
         either a read-only or write-enabled checkout.
 
     Parameters
@@ -717,7 +722,7 @@ class Datasets(object):
     def _ipython_key_completions_(self):
         '''Let ipython know that any key based access can use the dataset keys
 
-        Since we don't want to inheret from dict, nor mess with `__dir__` for the
+        Since we don't want to inherit from dict, nor mess with `__dir__` for the
         sanity of developers, this is the best way to ensure users can autocomplete
         keys.
 
@@ -772,7 +777,7 @@ class Datasets(object):
         key : string
             name of the dataset to remove from the repository. This will remove
             all records from the staging area (though the actual data and all
-            records are still accessable) if they were previously commited
+            records are still accessible) if they were previously committed
 
         Raises
         ------
@@ -879,7 +884,7 @@ class Datasets(object):
         '''Add related samples to un-named datasets with the same generated key.
 
         If you have multiple datasets in a checkout whose samples are related to
-        eachother in some manner, there are two ways of associating samples
+        each other in some manner, there are two ways of associating samples
         together:
 
         1) using named datasets and setting each tensor in each dataset to the
@@ -890,7 +895,7 @@ class Datasets(object):
         When method (2) - this method - is used, the internally generated sample
         ids will be set to the same value for the samples in each dataset. That
         way a user can iterate over the dataset key's in one sample, and use
-        those same keys to get the other releated tensor samples in another
+        those same keys to get the other related tensor samples in another
         dataset.
 
         Parameters
@@ -948,7 +953,7 @@ class Datasets(object):
         the same size that was initially specified upon dataset initialization.
         Variable size datasets on the other hand, can write samples with
         dimensions of any size less than a maximum which is required to be set
-        upon datset creation.
+        upon dataset creation.
 
         Parameters
         ----------
@@ -988,7 +993,7 @@ class Datasets(object):
         ValueError
             If provided name contains any non ascii, non alpha-numeric characters.
         ValueError
-            If required `shape` and `dtype` arguments are not provided in absense of
+            If required `shape` and `dtype` arguments are not provided in absence of
             `prototype` argument.
         ValueError
             If `prototype` argument is not a C contiguous ndarray.
@@ -1164,7 +1169,7 @@ class Datasets(object):
         stageenv : lmdb.Environment
             environment where staging records (dataenv) are opened in write mode.
         stagehashenv: lmdb.Environment
-            environment where the staged hash records are sored in write mode
+            environment where the staged hash records are stored in write mode
 
         Returns
         -------


### PR DESCRIPTION
## Motivation and Context
Why is this change required? What problem does it solve?:

This is the initial work on making hangar reads thread/process safe. The `batch_get` function is the preffered method for user interaction. 

If it fixes an open issue, please link to the issue here:

Addresses some of the requirements to enable: #13 

## Description
Describe your changes in detail:

`DatasetDataReader` class no longer contains references to lmdb environments. This change was made as it cannot be serialized and sent across processes. 

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Is this PR ready for review, or a work in progress?
- [ ] Ready for review
- [x] Work in progress

## How Has This Been Tested?
Put an `x` in the boxes that apply:
- [ ] Current tests cover modifications made
- [ ] New tests have been added to the test suite
- [ ] Modifications were made to existing tests to support these changes
- [x] Tests may be needed, but they are not included when the PR was proposed
- [ ] I don't know. Help!

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.rst)** document.
- [x] I have signed (or will sign when prompted) the tensorwork CLA.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
