### PR TITLE
bug fix dataset conflict

### DIFF
--- a/src/hangar/diff.py
+++ b/src/hangar/diff.py
@@ -626,8 +626,8 @@ class ThreeWayCommitDiffer(object):
         # addition conflicts
         addition_keys = self.am_dsetD.additions.intersection(self.ad_dsetD.additions)
         for dsetn in addition_keys:
-            m_srec = _schema_dict_to_nt(self.am_dsetD.d_data[dsetn])
-            d_srec = _schema_dict_to_nt(self.ad_dsetD.d_data[dsetn])
+            m_srec = _schema_dict_to_nt({dsetn: self.am_dsetD.d_data[dsetn]})
+            d_srec = _schema_dict_to_nt({dsetn: self.ad_dsetD.d_data[dsetn]})
             if m_srec != d_srec:
                 tempt1.append(dsetn)
         out['t1'] = tempt1
@@ -639,8 +639,8 @@ class ThreeWayCommitDiffer(object):
         # mutation conflicts
         mutation_keys = self.am_dsetD.mutations.intersection(self.ad_dsetD.mutations)
         for dsetn in mutation_keys:
-            m_srec = _schema_dict_to_nt(self.am_dsetD.d_data[dsetn])
-            d_srec = _schema_dict_to_nt(self.ad_dsetD.d_data[dsetn])
+            m_srec = _schema_dict_to_nt({dsetn: self.am_dsetD.d_data[dsetn]})
+            d_srec = _schema_dict_to_nt({dsetn: self.ad_dsetD.d_data[dsetn]})
             if m_srec != d_srec:
                 tempt3.append(dsetn)
         out['t3'] = tempt3


### PR DESCRIPTION
## Motivation and Context
There was a bug hidden in `dataset_conflicts` function which was letting the control-flow call `_schema_dict_to_nt` with a non-dictionary argument. We might have to start running mypy as part of CI


## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Is this PR ready for review, or a work in progress?
- [x] Ready for review
- [ ] Work in progress

## How Has This Been Tested?
Put an `x` in the boxes that apply:
- [ ] Current tests cover modifications made
- [ ] New tests have been added to the test suite
- [ ] Modifications were made to existing tests to support these changes
- [x] Tests may be needed, but they are not included when the PR was proposed
- [ ] I don't know. Help!

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.rst)** document.
- [x] I have signed (or will sign when prompted) the tensorwork CLA.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
