### PR TITLE
integer keys for dataset/metadata samples

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Improvements
 * Record format versioning and standardization so to not break backwards compatibility in the future. (`#70 <https://github.com/tensorwerk/hangar-py/pull/70>`__) `@rlizzo <https://github.com/rlizzo>`__
 * Backend addition and update developer protocols and documentation. (`#70 <https://github.com/tensorwerk/hangar-py/pull/70>`__) `@rlizzo <https://github.com/rlizzo>`__
 * Read-only checkout dataset sample ``get`` methods now are multithread and multiprocess safe. (`#84 <https://github.com/tensorwerk/hangar-py/pull/84>`__) `@rlizzo <https://github.com/rlizzo>`__
+* Samples can be assigned integer names in addition to ``string`` names (`#89 <https://github.com/tensorwerk/hangar-py/pull/89>`__) `@rlizzo <https://github.com/rlizzo>`__
 * Many tests added (including support for Mac OSX on Travis-CI).
 
 Bug Fixes

--- a/src/hangar/constants.py
+++ b/src/hangar/constants.py
@@ -38,6 +38,7 @@ SEP_CMT = ' << '
 SEP_SLC = "*"
 SEP_HSH = '$'
 
+K_INT = f'#'
 K_BRANCH = f'branch{SEP_KEY}'
 K_HEAD = 'head'
 K_REMOTES = f'remote{SEP_KEY}'

--- a/src/hangar/dataset.py
+++ b/src/hangar/dataset.py
@@ -2,7 +2,7 @@ import hashlib
 import logging
 from typing import Optional
 from multiprocessing import Pool, get_context, cpu_count
-from typing import MutableMapping
+from typing import MutableMapping, Union
 
 import lmdb
 import numpy as np
@@ -381,44 +381,44 @@ class DatasetDataWriter(DatasetDataReader):
         for k in self._fs.keys():
             self._fs[k].__exit__(*exc)
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: Union[str, int], value: np.ndarray) -> Union[str, int]:
         '''Store a piece of data in a dataset. Convenience method to :meth:`add`.
 
         .. seealso:: :meth:`add`
 
         Parameters
         ----------
-        key : str
+        key : Union[str, int]
             name of the sample to add to the dataset
         value : np.array
             tensor data to add as the sample
 
         Returns
         -------
-        str
+        Union[str, int]
             sample name of the stored data (assuming operation was successful)
         '''
         self.add(value, key)
         return key
 
-    def __delitem__(self, key):
+    def __delitem__(self, key: Union[str, int]) -> Union[str, int]:
         '''Remove a sample from the dataset. Convenience method to :meth:`remove`.
 
         .. seealso:: :meth:`remove`
 
         Parameters
         ----------
-        key : str
+        key : Union[str, int]
             Name of the sample to remove from the dataset
 
         Returns
         -------
-        str
+        Union[str, int]
             Name of the sample removed from the dataset (assuming operation successful)
         '''
         return self.remove(key)
 
-    @ property
+    @property
     def _backend(self) -> str:
         '''The default backend for the dataset which can be written to
 
@@ -429,20 +429,20 @@ class DatasetDataWriter(DatasetDataReader):
         '''
         return self._dflt_backend
 
-    def add(self, data: np.ndarray, name: str = None, **kwargs):
+    def add(self, data: np.ndarray, name: Union[str, int] = None, **kwargs) -> Union[str, int]:
         '''Store a piece of data in a dataset
 
         Parameters
         ----------
         data : np.ndarray
             data to store as a sample in the dataset.
-        name : str, optional
+        name : Union[str, int], optional
             name to assign to the same (assuming the dataset accepts named
             samples), by default None
 
         Returns
         -------
-        str
+        Union[str, int]
             sample name of the stored data (assuming the operation was successful)
 
         Raises
@@ -474,7 +474,7 @@ class DatasetDataWriter(DatasetDataReader):
         try:
             if self._samples_are_named and not is_suitable_user_key(name):
                 raise ValueError(
-                    f'Data name provided: `{name}` is invalid. Can only contain '
+                    f'Data name provided: `{name}` type: {type(name)} is invalid. Can only contain '
                     f'alpha-numeric or "." "_" "-" ascii characters (no whitespace).')
             elif not self._samples_are_named:
                 name = kwargs['bulkn'] if 'bulkn' in kwargs else parsing.generate_sample_name()
@@ -556,7 +556,7 @@ class DatasetDataWriter(DatasetDataReader):
 
         return name
 
-    def remove(self, name):
+    def remove(self, name: Union[str, int]) -> Union[str, int]:
         '''Remove a sample with the provided name from the dataset.
 
         .. Note::
@@ -579,12 +579,12 @@ class DatasetDataWriter(DatasetDataReader):
 
         Parameters
         ----------
-        name : str
+        name : Union[str, int]
             name of the sample to remove.
 
         Returns
         -------
-        str
+        Union[str, int]
             If the operation was successful, name of the data sample deleted.
 
         Raises
@@ -599,7 +599,7 @@ class DatasetDataWriter(DatasetDataReader):
         try:
             isRecordDeleted = self._dataTxn.delete(dataKey)
             if isRecordDeleted is False:
-                raise KeyError(f'No sample: {name} exists in dset: {self._dsetn}')
+                raise KeyError(f'No sample: {name} type: {type(name)} exists in: {self._dsetn}')
             del self._sspecs[name]
 
             dsetDataCountKey = parsing.dataset_record_count_db_key_from_raw_key(self._dsetn)

--- a/src/hangar/dataset.py
+++ b/src/hangar/dataset.py
@@ -1,8 +1,8 @@
 import hashlib
 import logging
 from typing import Optional
-from multiprocessing import Pool, get_context, cpu_count
-from typing import MutableMapping, Union
+from multiprocessing import get_context, cpu_count
+from typing import Union
 
 import lmdb
 import numpy as np
@@ -438,7 +438,9 @@ class DatasetDataWriter(DatasetDataReader):
             data to store as a sample in the dataset.
         name : Union[str, int], optional
             name to assign to the same (assuming the dataset accepts named
-            samples), by default None
+            samples), If str, can only contain alpha-numeric ascii characters
+            (in addition to '-', '.', '_'). Integer key must be >= 0. by default
+            None
 
         Returns
         -------
@@ -474,8 +476,8 @@ class DatasetDataWriter(DatasetDataReader):
         try:
             if self._samples_are_named and not is_suitable_user_key(name):
                 raise ValueError(
-                    f'Data name provided: `{name}` type: {type(name)} is invalid. Can only contain '
-                    f'alpha-numeric or "." "_" "-" ascii characters (no whitespace).')
+                    f'Name provided: `{name}` type: {type(name)} is invalid. Can only contain '
+                    f'alpha-numeric or "." "_" "-" ascii characters (no whitespace) or int >= 0')
             elif not self._samples_are_named:
                 name = kwargs['bulkn'] if 'bulkn' in kwargs else parsing.generate_sample_name()
 
@@ -707,7 +709,7 @@ class Datasets(object):
         res = f'\n Hangar {self.__class__.__name__}\
                 \n     Writeable: {bool(0 if self._mode == "r" else 1)}\
                 \n     Dataset Names:\
-                \n       - '                             + '\n       - '.join(self._datasets.keys())
+                \n       - '                                                         + '\n       - '.join(self._datasets.keys())
         p.text(res)
 
     def __repr__(self):

--- a/src/hangar/metadata.py
+++ b/src/hangar/metadata.py
@@ -27,7 +27,7 @@ class MetadataReader(object):
         It is important to realize that this is not intended to serve as a general
         store large amounts of textual data, and has no optimization to support such
         use cases at this time. This should only serve to attach helpful labels, or
-        other quick information primarily indented for human book-keeping, to the
+        other quick information primarily intended for human book-keeping, to the
         main tensor data!
 
     Parameters
@@ -295,7 +295,7 @@ class MetadataWriter(MetadataReader):
         Parameters
         ----------
         key : string
-            Name of the metadata piece, alphanumeric ascii chracters only
+            Name of the metadata piece, alphanumeric ascii characters only
         value : string
             Metadata value to store in the repository, any length of valid
             ascii characters.

--- a/src/hangar/metadata.py
+++ b/src/hangar/metadata.py
@@ -1,5 +1,5 @@
 import hashlib
-from typing import Optional
+from typing import Optional, Union, Iterable, Tuple
 import logging
 
 import lmdb
@@ -27,16 +27,16 @@ class MetadataReader(object):
         It is important to realize that this is not intended to serve as a general
         store large amounts of textual data, and has no optimization to support such
         use cases at this time. This should only serve to attach helpful labels, or
-        other quick information primarily intdented for human book-keeping, to the
+        other quick information primarily indented for human book-keeping, to the
         main tensor data!
 
     Parameters
     ----------
     dataenv : lmdb.Environment
-        the lmdb enviornment in which the data records are stored. this is
+        the lmdb environment in which the data records are stored. this is
         the same as the dataset data record environments.
     labelenv : lmdb.Environment
-        the lmdb envirionment in which the label hash key / values are stored
+        the lmdb environment in which the label hash key / values are stored
         permanently. When opened in by this reader instance, no write access
         is allowed.
     '''
@@ -65,7 +65,7 @@ class MetadataReader(object):
         self._labelTxn = self._TxnRegister.abort_reader_txn(self._labelenv)
         self._dataTxn = self._TxnRegister.abort_reader_txn(self._dataenv)
 
-    def __len__(self):
+    def __len__(self) -> int:
         '''Determine how many metadata key/value pairs are in the checkout
 
         Returns
@@ -85,14 +85,14 @@ class MetadataReader(object):
                 self._dataTxn = self._TxnRegister.abort_reader_txn(self._dataenv)
         return meta_count
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: Union[str, int]) -> str:
         '''Retrieve a metadata sample with a key. Convenience method for dict style access.
 
         .. seealso:: :meth:`get()`
 
         Parameters
         ----------
-        key : string
+        key : Union[str, int]
             metadata key to retrieve from the dataset
 
         Returns
@@ -102,12 +102,12 @@ class MetadataReader(object):
         '''
         return self.get(key)
 
-    def __contains__(self, key):
+    def __contains__(self, key: Union[str, int]) -> bool:
         '''Determine if a key with the provided name is in the metadata
 
         Parameters
         ----------
-        key : string
+        key : Union[str, int]
             key to check for containment testing
 
         Returns
@@ -116,64 +116,62 @@ class MetadataReader(object):
             True if key exists, False otherwise
         '''
         names = self._Query.metadata_names()
-        if key in names:
-            return True
-        else:
-            return False
+        ret = True if key in names else False
+        return ret
 
-    def __iter__(self):
+    def __iter__(self) -> Iterable:
         return self.keys()
 
     def _repr_pretty_(self, p, cycle):
-        res = f'\n Hangar Metadata\
-                \n     Writeable: {self.iswriteable}\
-                \n     Number of Keys: {len(self)}\n'
+        res = f'Hangar Metadata\
+                \n    Writeable: {self.iswriteable}\
+                \n    Number of Keys: {len(self)}\n'
         p.text(res)
 
     def __repr__(self):
-        res = f'\n Hangar Metadata\
-                \n     Writeable: {self.iswriteable}\
-                \n     Number of Keys: {len(self)}\n'
+        res = f'Hangar Metadata\
+                \n    Writeable: {self.iswriteable}\
+                \n    Number of Keys: {len(self)}\n'
         return res
 
     @property
-    def iswriteable(self):
+    def iswriteable(self) -> bool:
         '''Bool indicating if this metadata object is write-enabled. Read-only attribute.
         '''
         return self._is_writeable
 
-    def keys(self):
+    def keys(self) -> Iterable[Union[str, int]]:
         '''generator returning all metadata key names in the checkout
         '''
         names = self._Query.metadata_names()
         for name in names:
             yield name
 
-    def values(self):
+    def values(self) -> Iterable[str]:
         '''generator returning all metadata values in the checkout
         '''
         names = self._Query.metadata_names()
         for name in names:
             yield self.get(name)
 
-    def items(self):
+    def items(self) -> Iterable[Tuple[Union[str, int], str]]:
         '''generator returning all key/value pairs in the checkout.
         '''
         names = self._Query.metadata_names()
         for name in names:
             yield (name, self.get(name))
 
-    def get(self, key):
+    def get(self, key: Union[str, int]) -> str:
         '''retrieve a piece of metadata from the checkout.
 
         Parameters
         ----------
-        key : string
+        key : Union[str, int]
             The name of the metadata piece to retrieve.
 
         Returns
         -------
-        string
+        str
             The stored metadata value associated with the key.
 
         Raises
@@ -190,15 +188,14 @@ class MetadataReader(object):
 
         try:
             if not is_suitable_user_key(key):
-                msg = f'HANGAR VALUE ERROR:: metadata key: `{key}` not allowed. Can '\
-                      f'only contain alpha-numeric or "." "_" "-" ascii characters.'
-                raise ValueError(msg)
+                raise ValueError(
+                    f'metadata key: `{key}` not allowed. Can only contain '
+                    f'alpha-numeric or "." "_" "-" ascii characters.')
 
             refKey = parsing.metadata_record_db_key_from_raw_key(key)
             hashVal = self._dataTxn.get(refKey, default=False)
             if hashVal is False:
-                msg = f'HANGAR KEY ERROR:: No metadata key: `{key}` exists in checkout'
-                raise KeyError(msg)
+                raise KeyError(f'No metadata key: `{key}` exists in checkout')
 
             hash_spec = parsing.metadata_record_raw_val_from_db_val(hashVal)
             metaKey = parsing.hash_meta_db_key_from_raw_key(hash_spec)
@@ -221,7 +218,7 @@ class MetadataWriter(MetadataReader):
     '''Class implementing write access to repository metadata.
 
     Similar to the :class:`hangar.dataset.DatasetDataWriter`, this class
-    inherets the functionality of the :class:`MetadataReader` for reading. The
+    inherits the functionality of the :class:`MetadataReader` for reading. The
     only difference is that the reader will be initialized with a data record
     lmdb environment pointing to the staging area, and not a commit which is
     checked out.
@@ -256,43 +253,43 @@ class MetadataWriter(MetadataReader):
         self._labelTxn = self._TxnRegister.commit_writer_txn(self._labelenv)
         self._dataTxn = self._TxnRegister.commit_writer_txn(self._dataenv)
 
-    def __setitem__(self, key, value):
-        '''Store a key/value pair as metadata. Convenince method to :meth:`add`.
+    def __setitem__(self, key: Union[str, int], value: str) -> Union[str, int]:
+        '''Store a key/value pair as metadata. Convenience method to :meth:`add`.
 
         .. seealso:: :meth:`add`
 
         Parameters
         ----------
-        key : string
+        key : Union[str, int]
             name of the key to add as metadata
         value : string
             value to add as metadata
 
         Returns
         -------
-        str
+        Union[str, int]
             key of the stored metadata sample (assuming operation was successful)
         '''
         return self.add(key, value)
 
-    def __delitem__(self, key):
-        '''Remove a key/value pair from metadata. Convenence method to :meth:`remove`.
+    def __delitem__(self, key: Union[str, int]) -> Union[str, int]:
+        '''Remove a key/value pair from metadata. Convenience method to :meth:`remove`.
 
         .. seealso:: :meth:`remove`
 
         Parameters
         ----------
-        key : str
+        key : Union[str, int]
             Name of the metadata piece to remove.
 
         Returns
         -------
-        str
+        Union[str, int]
             Metadata key removed from the dataset (assuming operation successful)
         '''
         return self.remove(key)
 
-    def add(self, key, value):
+    def add(self, key: Union[str, int], value: str) -> Union[str, int]:
         '''Add a piece of metadata to the staging area of the next commit.
 
         Parameters
@@ -320,13 +317,12 @@ class MetadataWriter(MetadataReader):
         '''
         try:
             if not is_suitable_user_key(key):
-                msg = f'HANGAR VALUE ERROR:: metadata key: `{key}` not allowed. Must be '\
-                      f'str containing only alpha-numeric or "." "_" "-" ascii characters.'
-                raise ValueError(msg)
+                raise ValueError(
+                    f'Metadata key: `{key}` not allowed. Must be str or int containing '
+                    f'only alpha-numeric or "." "_" "-" ascii characters.')
             elif not (isinstance(value, str) and is_ascii(value)):
-                msg = f'HANGAR VALUE ERROR:: metadata value: `{value}` not allowed. '\
-                      f'Must be str with only ascii characters.'
-                raise ValueError(msg)
+                raise ValueError(
+                    f'Metadata Value: `{value}` not allowed. Must be ascii-only str')
         except ValueError as e:
             logger.error(e, exc_info=False)
             raise e from None
@@ -345,9 +341,9 @@ class MetadataWriter(MetadataReader):
             existingMetaRecVal = self._dataTxn.get(metaRecKey, default=False)
             if existingMetaRecVal:
                 if metaRecVal == existingMetaRecVal:
-                    msg = f'HANGAR KEY EXISTS ERROR:: metadata already contains key: `{key}` '\
-                          f'with value: `{value}` & hash: {val_hash}'
-                    raise LookupError(msg)
+                    raise LookupError(
+                        f'HANGAR KEY EXISTS ERROR:: metadata already contains key: `{key}` '
+                        f'with value: `{value}` & hash: {val_hash}')
             else:
                 # increment metadata record count
                 metaCountKey = parsing.metadata_count_db_key()
@@ -369,7 +365,7 @@ class MetadataWriter(MetadataReader):
 
         return key
 
-    def remove(self, key):
+    def remove(self, key: Union[str, int]) -> Union[str, int]:
         '''Remove a piece of metadata from the staging area of the next commit.
 
         Parameters

--- a/src/hangar/utils.py
+++ b/src/hangar/utils.py
@@ -8,6 +8,7 @@ from contextlib import contextmanager
 from datetime import timedelta
 from functools import partial
 from numbers import Number
+from typing import Union
 
 import blosc
 import wrapt
@@ -83,14 +84,14 @@ def symlink_rel(src: os.PathLike, dst: os.PathLike):
 SuitableCharRE = re.compile(r'[\w\.\-\_]+$', flags=re.ASCII)
 
 
-def is_suitable_user_key(str_data: str) -> bool:
+def is_suitable_user_key(key: Union[str, int]) -> bool:
     '''Checks if string contains only alpha-numeric ascii chars or ['.', '-' '_'] (no whitespace)
 
     Necessary because python 3.6 does not have a str.isascii() method.
 
     Parameters
     ----------
-    str_data : str
+    key : Union[str, int]
         string to check if it contains only ascii characters
 
     Returns
@@ -99,6 +100,10 @@ def is_suitable_user_key(str_data: str) -> bool:
         True if only ascii characters in the string, else False.
     '''
     try:
+        if isinstance(key, (str, int)):
+            str_data = str(key)
+        else:
+            raise TypeError
         return bool(SuitableCharRE.match(str_data))
     except TypeError:
         return False

--- a/src/hangar/utils.py
+++ b/src/hangar/utils.py
@@ -100,7 +100,9 @@ def is_suitable_user_key(key: Union[str, int]) -> bool:
         True if only ascii characters in the string, else False.
     '''
     try:
-        if isinstance(key, (str, int)):
+        if isinstance(key, int) and (key >= 0):
+            str_data = str(key)
+        elif isinstance(key, str):
             str_data = str(key)
         else:
             raise TypeError

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,6 +109,7 @@ def repo_1_br_no_conf(request, repo):
     for idx in range(10, 20):
         dummyData[:] = idx
         co2.datasets['dummy'][str(idx)] = dummyData
+        co2.datasets['dummy'][idx] = dummyData
     co2.metadata['foo'] = 'bar'
     co2.commit('first commit on test branch adding non-conflict data and meta')
     co2.close()
@@ -124,6 +125,7 @@ def repo_2_br_no_conf(repo_1_br_no_conf):
     for idx in range(20, 30):
         dummyData[:] = idx
         co1.datasets['dummy'][str(idx)] = dummyData
+        co1.datasets['dummy'][idx] = dummyData
     co1.commit('second commit on master adding non-conflict data')
     co1.close()
     return repo

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -219,6 +219,24 @@ class TestDataWithFixedSizedDataset(object):
         assert np.allclose(co.datasets['_dset'][2], secondArray)
         co.close()
 
+    def test_cannot_add_data_negative_int_key(self, written_repo, array5by7):
+        co = written_repo.checkout(write=True)
+        dset = co.datasets['_dset']
+        with pytest.raises(ValueError):
+            dset[-1] = array5by7
+        assert len(co.datasets['_dset']) == 0
+        co.close()
+
+    def test_cannot_add_data_float_key(self, written_repo, array5by7):
+        co = written_repo.checkout(write=True)
+        dset = co.datasets['_dset']
+        with pytest.raises(ValueError):
+            dset[2.1] = array5by7
+        with pytest.raises(ValueError):
+            dset[0.0] = array5by7
+        assert len(co.datasets['_dset']) == 0
+        co.close()
+
     def test_add_data_mixed_int_str_keys(self, written_repo, array5by7):
         co = written_repo.checkout(write=True)
         dset = co.datasets['_dset']

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -190,22 +190,53 @@ class TestDataWithFixedSizedDataset(object):
             co.datasets.get('_dset').get('1'),
             array5by7)
 
-    def test_add_data(self, written_repo, array5by7):
+    def test_add_data_str_keys(self, written_repo, array5by7):
         co = written_repo.checkout(write=True)
         dset = co.datasets['_dset']
         with pytest.raises(KeyError):
             dset['somerandomkey']
 
-        with pytest.raises(ValueError):
-            dset[1] = array5by7
         dset['1'] = array5by7
         dset.add(array5by7, '2')
         co.commit('this is a commit message')
         co.close()
         co = written_repo.checkout()
-        assert np.allclose(
-            co.datasets['_dset']['1'],
-            co.datasets['_dset']['2'])
+        assert np.allclose(co.datasets['_dset']['1'], array5by7)
+        assert np.allclose(co.datasets['_dset']['2'], array5by7)
+        co.close()
+
+    def test_add_data_int_keys(self, written_repo, array5by7):
+        co = written_repo.checkout(write=True)
+        dset = co.datasets['_dset']
+
+        dset[1] = array5by7
+        secondArray = array5by7 + 1
+        dset.add(secondArray, 2)
+        co.commit('this is a commit message')
+        co.close()
+        co = written_repo.checkout()
+        assert np.allclose(co.datasets['_dset'][1], array5by7)
+        assert np.allclose(co.datasets['_dset'][2], secondArray)
+        co.close()
+
+    def test_add_data_mixed_int_str_keys(self, written_repo, array5by7):
+        co = written_repo.checkout(write=True)
+        dset = co.datasets['_dset']
+
+        dset[1] = array5by7
+        newFirstArray = array5by7 + 1
+        dset['1'] = newFirstArray
+        secondArray = array5by7 + 2
+        dset.add(secondArray, 2)
+        thirdArray = array5by7 + 3
+        dset.add(thirdArray, '2')
+        co.commit('this is a commit message')
+        co.close()
+        co = written_repo.checkout()
+        assert np.allclose(co.datasets['_dset'][1], array5by7)
+        assert np.allclose(co.datasets['_dset']['1'], newFirstArray)
+        assert np.allclose(co.datasets['_dset'][2], secondArray)
+        assert np.allclose(co.datasets['_dset']['2'], thirdArray)
         co.close()
 
     def test_add_with_wrong_argument_order(self, w_checkout, array5by7):
@@ -358,10 +389,9 @@ class TestDataWithFixedSizedDataset(object):
         with pytest.raises(ValueError):
             dset.add(randomsizedarray)
 
-        dset_no_name = co.datasets.init_dataset(
-            'dset_no_name',
-            prototype=randomsizedarray,
-            named_samples=False)
+        dset_no_name = co.datasets.init_dataset('dset_no_name',
+                                                prototype=randomsizedarray,
+                                                named_samples=False)
         dset_no_name.add(randomsizedarray)
         assert np.allclose(next(dset_no_name.values()), randomsizedarray)
         co.close()


### PR DESCRIPTION
## Motivation and Context
#### _Why is this change required? What problem does it solve?:_

extends the simulated dict interface to integer keys for `dataset` and `metadata` samples

#### _If it fixes an open issue, please link to the issue here:_

closes #86 

## Description
#### _Describe your changes in detail:_

Parsing functions updated to append `#` character to integer keys before serialization/deserialization in lmdb. Upon read appropriate strings are stripped of `#` and transformed to `int` for in memory access

Tests updated to reflect change in semantics and ensure adequate coverage. 

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Documentation update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Is this PR ready for review, or a work in progress?
- [x] Ready for review
- [ ] Work in progress

## How Has This Been Tested?
Put an `x` in the boxes that apply:
- [x] Current tests cover modifications made
- [x] New tests have been added to the test suite
- [ ] Modifications were made to existing tests to support these changes
- [ ] Tests may be needed, but they are not included when the PR was proposed
- [ ] I don't know. Help!

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.rst)** document.
- [x] I have signed (or will sign when prompted) the tensorwork CLA.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
