### PR TITLE
Dataset iterator bugfix

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -11,6 +11,8 @@ Repository
 .. automodule:: hangar.repository
    :members:
 
+.. autoclass:: Remotes
+   :members:
 
 Write Enabled Checkout
 ======================
@@ -30,6 +32,7 @@ Dataset Data
 
 .. autoclass:: hangar.dataset.DatasetDataWriter
    :members:
+   :inherited-members:
    :special-members: __getitem__, __setitem__, __delitem__, __contains__, __len__, __iter__
 
 Metadata
@@ -37,6 +40,7 @@ Metadata
 
 .. autoclass:: hangar.metadata.MetadataWriter
    :members:
+   :inherited-members:
    :special-members: __getitem__, __setitem__, __delitem__, __contains__, __len__, __iter__
 
 Differ

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,6 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.napoleon',
     'sphinx.ext.todo',
-    'sphinx.ext.viewcode',
     'sphinx_click.ext',
     'nbsphinx',
     'recommonmark',
@@ -65,6 +64,7 @@ html_short_title = '%s-%s' % (project, version)
 napoleon_use_ivar = True
 napoleon_use_rtype = True
 napoleon_use_param = True
+napoleon_include_init_with_doc = True
 
 add_module_names = False
 doctest_test_doctest_blocks = None

--- a/src/hangar/checkout.py
+++ b/src/hangar/checkout.py
@@ -105,7 +105,7 @@ class ReaderCheckout(object):
             raise PermissionError(err) from None
 
     @property
-    def datasets(self):
+    def datasets(self) -> Datasets:
         '''Provides access to dataset interaction object.
 
         .. seealso::
@@ -115,7 +115,7 @@ class ReaderCheckout(object):
 
         Returns
         -------
-        weakref.proxy
+        Datasets
             weakref proxy to the datasets object which behaves exactly like a
             datasets accessor class but which can be invalidated when the writer
             lock is released.
@@ -125,7 +125,7 @@ class ReaderCheckout(object):
         return wr
 
     @property
-    def metadata(self):
+    def metadata(self) -> MetadataReader:
         '''Provides access to metadata interaction object.
 
         .. seealso::
@@ -135,7 +135,7 @@ class ReaderCheckout(object):
 
         Returns
         -------
-        weakref.proxy
+        MetadataReader
             weakref proxy to the metadata object which behaves exactly like a
             metadata class but which can be invalidated when the writer lock is
             released.
@@ -145,17 +145,17 @@ class ReaderCheckout(object):
         return wr
 
     @property
-    def diff(self):
+    def diff(self) -> ReaderUserDiff:
         '''Access the differ methods for a read-only checkout.
 
         .. seealso::
 
-            The class :class:`hangar.diff.ReaderUserDiff` contains all methods accessible
+            The class :class:`ReaderUserDiff` contains all methods accessible
             by this property accessor
 
         Returns
         -------
-        weakref.proxy
+        ReaderUserDiff
             weakref proxy to the differ object (and contained methods) which behaves
             exactly like the differ class but which can be invalidated when the
             writer lock is released.
@@ -165,7 +165,7 @@ class ReaderCheckout(object):
         return wr
 
     @property
-    def commit_hash(self):
+    def commit_hash(self) -> str:
         '''Commit hash this read-only checkout's data is read from.
 
         Returns
@@ -176,7 +176,7 @@ class ReaderCheckout(object):
         self.__verify_checkout_alive()
         return self._commit_hash
 
-    def close(self):
+    def close(self) -> None:
         '''Gracefully close the reader checkout object.
 
         Though not strictly required for reader checkouts (as opposed to
@@ -287,7 +287,7 @@ class WriterCheckout(object):
         return res
 
     @property
-    def datasets(self):
+    def datasets(self) -> Datasets:
         '''Provides access to dataset interaction object.
 
         .. seealso::
@@ -297,7 +297,7 @@ class WriterCheckout(object):
 
         Returns
         -------
-        weakref.proxy
+        Datasets
             weakref proxy to the datasets object which behaves exactly like a
             datasets accessor class but which can be invalidated when the writer
             lock is released.
@@ -307,7 +307,7 @@ class WriterCheckout(object):
         return wr
 
     @property
-    def metadata(self):
+    def metadata(self) -> MetadataWriter:
         '''Provides access to metadata interaction object.
 
         .. seealso::
@@ -317,7 +317,7 @@ class WriterCheckout(object):
 
         Returns
         -------
-        weakref.proxy
+        MetadataWriter
             weakref proxy to the metadata object which behaves exactly like a
             metadata class but which can be invalidated when the writer lock is
             released.
@@ -327,7 +327,7 @@ class WriterCheckout(object):
         return wr
 
     @property
-    def diff(self):
+    def diff(self) -> WriterUserDiff:
         '''Access the differ methods which are aware of any staged changes.
 
         .. seealso::
@@ -337,7 +337,7 @@ class WriterCheckout(object):
 
         Returns
         -------
-        weakref.proxy
+        WriterUserDiff
             weakref proxy to the differ object (and contained methods) which behaves
             exactly like the differ class but which can be invalidated when the
             writer lock is released.
@@ -347,19 +347,19 @@ class WriterCheckout(object):
         return wr
 
     @property
-    def branch_name(self):
+    def branch_name(self) -> str:
         '''Branch this write enabled checkout's staging area was based on.
 
         Returns
         -------
-        string
+        str
             name of the branch whose commit HEAD changes are staged from.
         '''
         self.__acquire_writer_lock()
         return self._branch_name
 
     @property
-    def commit_hash(self):
+    def commit_hash(self) -> str:
         '''Commit hash which the staging area of `branch_name` is based on.
 
         Returns
@@ -527,7 +527,7 @@ class WriterCheckout(object):
             branchenv=self._branchenv,
             branch_name=self._branch_name)
 
-    def commit(self, commit_message):
+    def commit(self, commit_message: str) -> str:
         '''commit the changes made in the staging area.
 
         This creates a new commit on the checkout branch.
@@ -568,7 +568,7 @@ class WriterCheckout(object):
         logger.info(f'Commit completed. Commit hash: {commit_hash}')
         return commit_hash
 
-    def reset_staging_area(self):
+    def reset_staging_area(self) -> str:
         '''Perform a hard reset of the staging area to the last commit head.
 
         After this operation is performed, the writer checkout will be
@@ -627,7 +627,7 @@ class WriterCheckout(object):
             branch_name=self._branch_name)
         return head_commit
 
-    def close(self):
+    def close(self) -> None:
         '''Close all handles to the writer checkout and release the writer lock.
 
         Failure to call this method after the writer checkout has been used will

--- a/src/hangar/remotes.py
+++ b/src/hangar/remotes.py
@@ -3,7 +3,7 @@ import time
 import logging
 import tempfile
 import warnings
-from typing import List, NamedTuple, Optional, Union, Sequence
+from typing import List, NamedTuple, Optional, Sequence
 from contextlib import closing
 from collections import defaultdict
 

--- a/src/hangar/repository.py
+++ b/src/hangar/repository.py
@@ -2,7 +2,7 @@ import os
 import logging
 import weakref
 import warnings
-from typing import Union, Optional
+from typing import Union, Optional, List
 
 from . import merger
 from . import constants as c
@@ -97,24 +97,33 @@ class Repository(object):
 
     @property
     def remote(self) -> Remotes:
-        '''Accessor to the methods controlling remote interactions
+        '''Accessor to the methods controlling remote interactions.
+
+        .. seealso::
+
+           :class:`Remotes` for available methods of this property
+
+        Returns
+        -------
+        Remotes
+            Accessor object methods for controlling remote interactions.
         '''
         proxy = weakref.proxy(self._remote)
         return proxy
 
     @property
-    def repo_path(self):
+    def repo_path(self) -> os.PathLike:
         '''Return the path to the repository on disk, read-only attribute
 
         Returns
         -------
-        str
+        os.PathLike
             path to the specified repository, not including `__hangar` directory
         '''
         return os.path.dirname(self._repo_path)
 
     @property
-    def writer_lock_held(self):
+    def writer_lock_held(self) -> bool:
         '''Check if the writer lock is currently marked as held. Read-only attribute.
 
         Returns
@@ -158,7 +167,7 @@ class Repository(object):
 
         Returns
         -------
-        object
+        Union[ReaderCheckout, WriterCheckout]
             Checkout object which can be used to interact with the repository
             data
         '''
@@ -299,7 +308,7 @@ class Repository(object):
             commit on the printed log graph
         Returns
         -------
-        dict
+        Optional[dict]
             Dict containing the commit ancestor graph, and all specifications.
         '''
         self.__verify_repo_initialized()
@@ -344,7 +353,7 @@ class Repository(object):
 
         Returns
         -------
-        dict
+        Optional[dict]
             contents of the entire repository (if `return_contents=True`)
         '''
         self.__verify_repo_initialized()
@@ -373,7 +382,7 @@ class Repository(object):
         eco = ecosystem.get_versions()
         return eco
 
-    def merge(self, message, master_branch, dev_branch):
+    def merge(self, message: str, master_branch: str, dev_branch: str) -> str:
         '''Perform a merge of the changes made on two branches.
 
         Parameters
@@ -403,7 +412,7 @@ class Repository(object):
 
         return commit_hash
 
-    def create_branch(self, branch_name, base_commit=None):
+    def create_branch(self, branch_name: str, base_commit: str = None) -> str:
         '''create a branch with the provided name from a certain commit.
 
         If no base commit hash is specified, the current writer branch HEAD
@@ -445,7 +454,7 @@ class Repository(object):
         '''
         raise NotImplementedError()
 
-    def list_branches(self):
+    def list_branches(self) -> List[str]:
         '''list all branch names created in the repository.
 
         Returns
@@ -457,7 +466,7 @@ class Repository(object):
         branches = heads.get_branch_names(self._env.branchenv)
         return branches
 
-    def force_release_writer_lock(self):
+    def force_release_writer_lock(self) -> bool:
         '''Force release the lock left behind by an unclosed writer-checkout
 
         .. warning::

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -95,7 +95,7 @@ class TestCheckout(object):
         with pytest.raises(ReferenceError):
             shouldFail = dset['1']
 
-    def test_reader_dset_obj_not_accessible_after_close(self, writtenwritten_two_cmt_repo_repo):
+    def test_reader_dset_obj_not_accessible_after_close(self, written_two_cmt_repo):
         repo = written_two_cmt_repo
         co = repo.checkout(write=False)
         dsets = co.datasets

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -38,8 +38,8 @@ class TestCheckout(object):
             co.metadata.add('a', 'b')
         co.close()
 
-    def test_writer_dset_obj_not_accessible_after_close(self, written_repo):
-        repo = written_repo
+    def test_writer_dset_obj_not_accessible_after_close(self, written_two_cmt_repo):
+        repo = written_two_cmt_repo
         co = repo.checkout(write=True)
         dsets = co.datasets
         dset = co.datasets['_dset']
@@ -52,8 +52,8 @@ class TestCheckout(object):
         with pytest.raises(ReferenceError):
             dset.__dict__
 
-    def test_writer_dset_obj_dataset_iter_values_not_accessible_after_close(self, written_repo):
-        repo = written_repo
+    def test_writer_dset_obj_dataset_iter_values_not_accessible_after_close(self, written_two_cmt_repo):
+        repo = written_two_cmt_repo
         co = repo.checkout(write=True)
         oldObjs = []
         for oldObj in co.datasets.values():
@@ -64,8 +64,8 @@ class TestCheckout(object):
             with pytest.raises(ReferenceError):
                 oldObj.__dict__
 
-    def test_writer_dset_obj_dataset_iter_items_not_accessible_after_close(self, written_repo):
-        repo = written_repo
+    def test_writer_dset_obj_dataset_iter_items_not_accessible_after_close(self, written_two_cmt_repo):
+        repo = written_two_cmt_repo
         co = repo.checkout(write=True)
         oldObjs = {}
         for oldName, oldObj in co.datasets.items():
@@ -95,8 +95,8 @@ class TestCheckout(object):
         with pytest.raises(ReferenceError):
             shouldFail = dset['1']
 
-    def test_reader_dset_obj_not_accessible_after_close(self, written_repo):
-        repo = written_repo
+    def test_reader_dset_obj_not_accessible_after_close(self, writtenwritten_two_cmt_repo_repo):
+        repo = written_two_cmt_repo
         co = repo.checkout(write=False)
         dsets = co.datasets
         dset = co.datasets['_dset']
@@ -109,8 +109,8 @@ class TestCheckout(object):
         with pytest.raises(ReferenceError):
             dset.__dict__
 
-    def test_reader_dset_obj_dataset_iter_values_not_accessible_after_close(self, written_repo):
-        repo = written_repo
+    def test_reader_dset_obj_dataset_iter_values_not_accessible_after_close(self, written_two_cmt_repo):
+        repo = written_two_cmt_repo
         co = repo.checkout(write=False)
         oldObjs = []
         for oldObj in co.datasets.values():
@@ -121,8 +121,8 @@ class TestCheckout(object):
             with pytest.raises(ReferenceError):
                 oldObj.__dict__
 
-    def test_reader_dset_obj_dataset_iter_items_not_accessible_after_close(self, written_repo):
-        repo = written_repo
+    def test_reader_dset_obj_dataset_iter_items_not_accessible_after_close(self, written_two_cmt_repo):
+        repo = written_two_cmt_repo
         co = repo.checkout(write=False)
         oldObjs = {}
         for oldName, oldObj in co.datasets.items():
@@ -133,6 +133,42 @@ class TestCheckout(object):
             assert isinstance(name, str)
             with pytest.raises(ReferenceError):
                 obj.__dict__
+
+    def test_reader_dataset_context_manager_not_accessible_after_close(self, written_two_cmt_repo):
+        repo = written_two_cmt_repo
+        co = repo.checkout(write=False)
+        dset = co.datasets['_dset']
+        klist = []
+        with dset as ds:
+            for k in ds.keys():
+                klist.append(k)
+                a = ds
+        co.close()
+
+        with pytest.raises(ReferenceError):
+            a.__dict__
+        with pytest.raises(ReferenceError):
+            ds.__dict__
+        with pytest.raises(ReferenceError):
+            dset[klist[0]]
+
+    def test_writer_dataset_context_manager_not_accessible_after_close(self, written_two_cmt_repo):
+        repo = written_two_cmt_repo
+        co = repo.checkout(write=True)
+        dset = co.datasets['_dset']
+        with dset as ds:
+            # for k in ds.keys():
+            #     klist.append(k)
+            a = ds
+            a['1232'] = np.random.randn(5, 7).astype(np.float32)
+        co.close()
+
+        with pytest.raises(ReferenceError):
+            a.__dict__
+        with pytest.raises(ReferenceError):
+            ds.__dict__
+        with pytest.raises(ReferenceError):
+            dset['1232']
 
     def test_writer_metadata_obj_not_accessible_after_close(self, written_repo):
         repo = written_repo

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -316,7 +316,7 @@ def test_start_server():
     runner = CliRunner()
     with runner.isolated_filesystem():
         startTime = time.time()
-        res = runner.invoke(cli.server, ['--ip', 'localhost', '--port', '50111', '--timeout', '3'])
-        assert time.time() - startTime >= 3
+        res = runner.invoke(cli.server, ['--ip', 'localhost', '--port', '50111', '--timeout', '1'])
+        assert time.time() - startTime >= 1
         assert res.exit_code == 0
         assert res.stdout.startswith('Hangar Server Started')

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -713,8 +713,8 @@ class TestMultiprocessDatasetReads(object):
             if cIdx != 0:
                 co = repo.checkout(write=True)
             with co.datasets['_dset'] as d:
-                kstart = 100 * cIdx
-                for sIdx in range(100):
+                kstart = 20 * cIdx
+                for sIdx in range(20):
                     arr = np.random.randn(20, 20).astype(np.float32) * 100
                     sName = str(sIdx + kstart)
                     d[sName] = arr
@@ -728,7 +728,7 @@ class TestMultiprocessDatasetReads(object):
         for cmt, sampList in masterCmtList:
             nco = repo.checkout(write=False, commit=cmt)
             ds = nco.datasets['_dset']
-            keys = [str(i) for i in range(100 + (100*cmtIdx))]
+            keys = [str(i) for i in range(20 + (20*cmtIdx))]
             with get_context('spawn').Pool(2) as P:
                 cmtData = P.map(ds.get, keys)
             for data, sampData in zip(cmtData, sampList):
@@ -746,8 +746,8 @@ class TestMultiprocessDatasetReads(object):
             if cIdx != 0:
                 co = repo.checkout(write=True)
             with co.datasets['_dset'] as d:
-                kstart = 100 * cIdx
-                for sIdx in range(100):
+                kstart = 20 * cIdx
+                for sIdx in range(20):
                     arr = np.random.randn(20, 20).astype(np.float32) * 100
                     sName = str(sIdx + kstart)
                     d[sName] = arr
@@ -761,7 +761,7 @@ class TestMultiprocessDatasetReads(object):
         for cmt, sampList in masterCmtList:
             nco = repo.checkout(write=False, commit=cmt)
             ds = nco.datasets['_dset']
-            keys = [str(i) for i in range(100 + (100*cmtIdx))]
+            keys = [str(i) for i in range(20 + (20*cmtIdx))]
             cmtData = ds.get_batch(keys, n_cpus=2)
             for data, sampData in zip(cmtData, sampList):
                 assert np.allclose(data, sampData) is True
@@ -774,7 +774,7 @@ class TestMultiprocessDatasetReads(object):
         co.datasets.init_dataset(name='_dset', shape=(20, 20), dtype=np.float32, backend=backend)
         masterSampList = []
         with co.datasets['_dset'] as d:
-            for sIdx in range(100):
+            for sIdx in range(20):
                 arr = np.random.randn(20, 20).astype(np.float32) * 100
                 sName = str(sIdx)
                 d[sName] = arr
@@ -788,14 +788,14 @@ class TestMultiprocessDatasetReads(object):
 
         # superset of keys fails
         with pytest.raises(KeyError):
-            keys = [str(i) for i in range(104)]
+            keys = [str(i) for i in range(24)]
             ds.get_batch(keys, n_cpus=2)
 
         # subset of keys works
-        keys = [str(i) for i in range(20, 40)]
+        keys = [str(i) for i in range(10, 20)]
         cmtData = ds.get_batch(keys, n_cpus=2)
         for idx, data in enumerate(cmtData):
-            assert np.allclose(data, masterSampList[20+idx]) is True
+            assert np.allclose(data, masterSampList[10+idx]) is True
         nco.close()
 
     def test_writer_iterating_over_keys_can_have_additions_made_no_error(self, written_two_cmt_repo):


### PR DESCRIPTION
## Motivation and Context
#### _Why is this change required? What problem does it solve?:_

Bug where `write-enabled` checkouts could iterate over the dataset keys/values/items, and if they mutated the `dset` at the same time, a python `RuntimeError` would be thrown. 

```python
co = repo.checkout(write=True)
    dset = co.datasets['_dset']
    with dset as ds:
        for idx, k in enumerate(ds.keys()):
            ds['1232'] = np.random.randn(5, 7).astype(np.float32)

-------- RuntimeError (`dictionary changed size during iteration`) -----------

```

## Description
#### _Describe your changes in detail:_

From pure generator
```python 
for k in self.keysdict:
    yield k
```

to formal return
```python
for k in list(keys):
    yield k
```

Only for write-enabled checkout, as reader-checkouts cannot modify the samples dict by any means. 

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Documentation update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Is this PR ready for review, or a work in progress?
- [x] Ready for review
- [ ] Work in progress

## How Has This Been Tested?
Put an `x` in the boxes that apply:
- [ ] Current tests cover modifications made
- [x] New tests have been added to the test suite
- [ ] Modifications were made to existing tests to support these changes
- [ ] Tests may be needed, but they are not included when the PR was proposed
- [ ] I don't know. Help!

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.rst)** document.
- [x] I have signed (or will sign when prompted) the tensorwork CLA.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
