### PR TITLE
Bugfix: Variable Size Arrayset Less Dimensions

### DIFF
--- a/src/hangar/arrayset.py
+++ b/src/hangar/arrayset.py
@@ -538,8 +538,6 @@ class ArraysetDataWriter(ArraysetDataReader):
         ValueError
             If no `name` arg was provided for arrayset requiring named samples.
         ValueError
-            If input data tensor rank exceeds specified rank of arrayset samples.
-        ValueError
             For variable shape arraysets, if a dimension size of the input data
             tensor exceeds specified max dimension size of the arrayset samples.
         ValueError
@@ -573,9 +571,6 @@ class ArraysetDataWriter(ArraysetDataReader):
                 raise ValueError(f'`data` must be "C" contiguous array.')
 
             if self._schema_variable is True:
-                # if data.ndim != len(self._schema_max_shape):
-                #     raise ValueError(
-                #         f'`data` rank: {data.ndim} != aset rank: {len(self._schema_max_shape)}')
                 for dDimSize, schDimSize in zip(data.shape, self._schema_max_shape):
                     if dDimSize > schDimSize:
                         raise ValueError(
@@ -1092,11 +1087,11 @@ class Arraysets(object):
             all samples must be provided names, if not, no name will be assigned.
             defaults to True, which means all samples should have names.
         variable_shape : bool, optional
-            If this is a variable sized arrayset. If true, a the maximum shape is
-            set from the provided `shape` or `prototype` argument. Any sample
-            added to the arrayset can then have dimension sizes <= to this
-            initial specification (so long as they have the same rank as what
-            was specified) defaults to False.
+            If this is a variable sized arrayset. If true, a the maximum shape
+            is set from the provided `shape` or `prototype` argument. Any
+            sample added to the arrayset can then have dimension sizes <= to
+            this initial specification and rank <= rank of specification.
+            defaults to False.
         backend : DEVELOPER USE ONLY. str, optional, kwarg only
             Backend which should be used to write the arrayset files on disk.
 

--- a/src/hangar/arrayset.py
+++ b/src/hangar/arrayset.py
@@ -573,9 +573,9 @@ class ArraysetDataWriter(ArraysetDataReader):
                 raise ValueError(f'`data` must be "C" contiguous array.')
 
             if self._schema_variable is True:
-                if data.ndim != len(self._schema_max_shape):
-                    raise ValueError(
-                        f'`data` rank: {data.ndim} != aset rank: {len(self._schema_max_shape)}')
+                # if data.ndim != len(self._schema_max_shape):
+                #     raise ValueError(
+                #         f'`data` rank: {data.ndim} != aset rank: {len(self._schema_max_shape)}')
                 for dDimSize, schDimSize in zip(data.shape, self._schema_max_shape):
                     if dDimSize > schDimSize:
                         raise ValueError(

--- a/src/hangar/backends/hdf5_00.py
+++ b/src/hangar/backends/hdf5_00.py
@@ -28,6 +28,18 @@ Storage Method
 *  Compression Filters, Chunking Configuration/Options are applied globally for
    all ``datasets`` in a file at dataset creation time.
 
+*  For subarrays with rank < rank of schema (in ``variable_sized`` arraysets),
+   the data is written to the ``zeroth`` index of a larger hyperslab selection
+   normally filled by a full rank sample. While this allows lower rank samples
+   to be added, is complicates subarray slicing because we need to
+   differentiate between user defined sample shapes where an array is provided
+   with a zero-length dimension (``unsqueeze(0)``) and those which hangar
+   specified for the subarray slice. A special shape value ``x`` is used to
+   indicate this in the ``shape`` record field. When hangar encounters this,
+   it will not create a ranged slice object, but a fixed dimension field
+   (``value = 0``) upon reading/writing. Outisde of reading/writing, this
+   ``x`` value will remain in the ``shape`` record.
+
 Record Format
 =============
 
@@ -60,7 +72,7 @@ Examples
 
    ``Record Data => "00:2HvGf9$0 0*10"``
 
-1)  Adding to a piece of data to a the middle of a file:
+2)  Adding to a piece of data to a the middle of a file:
 
     *  Array shape (Subarray Shape): (20, 2, 3)
     *  File UID: "WzUtdu"
@@ -68,6 +80,15 @@ Examples
     *  Collection Index: 199
 
     ``Record Data => "00:WzUtdu$3 199*20 2 3"``
+
+3)  Adding to a piece of data with rank dimension < schema:
+
+    *  Array shape (Subarray Shape): (5)  # schema rank = 3
+    *  File UID: "O2EBcV"
+    *  Dataset Number: "0"
+    *  Collection Index: 2
+
+    ``Record Data => b'00:O2EBcV$0 2*x x 5'``
 
 
 Technical Notes

--- a/src/hangar/backends/numpy_10.py
+++ b/src/hangar/backends/numpy_10.py
@@ -21,6 +21,18 @@ Storage Method
      4, 3)``. The first index in the array is referred to as a "collection
      index".
 
+*  For subarrays with rank < rank of schema (in ``variable_sized`` arraysets),
+   the data is written to the ``zeroth`` index of a larger hyperslab selection
+   normally filled by a full rank sample. While this allows lower rank samples
+   to be added, is complicates subarray slicing because we need to
+   differentiate between user defined sample shapes where an array is provided
+   with a zero-length dimension (``unsqueeze(0)``) and those which hangar
+   specified for the subarray slice. A special shape value ``x`` is used to
+   indicate this in the ``shape`` record field. When hangar encounters this,
+   it will not create a ranged slice object, but a fixed dimension field
+   (``value = 0``) upon reading/writing. Outisde of reading/writing, this
+   ``x`` value will remain in the ``shape`` record.
+
 Record Format
 =============
 
@@ -53,7 +65,7 @@ Examples
 
     ``Record Data => '10:NJUUUK$900338819$2*10'``
 
-1)  Adding to a piece of data to a the middle of a file:
+2)  Adding to a piece of data to a the middle of a file:
 
     *  Array shape (Subarray Shape): (20, 2, 3)
     *  File UID: "Mk23nl"
@@ -61,6 +73,15 @@ Examples
     *  Collection Index: 199
 
     ``Record Data => "10:Mk23nl$2546668575$199*20 2 3"``
+
+3)  Adding to a piece of data with rank dimension < schema:
+
+    *  Array shape (Subarray Shape): (2, 3)  # schema rank = 3
+    *  File UID: "LWtfVS"
+    *  Alder32 Checksum: 4050125881
+    *  Collection Index: 3
+
+    ``Record Data => b'10:LWtfVS$4050125881$3*x 2 3'``
 
 
 Technical Notes

--- a/tests/test_remotes.py
+++ b/tests/test_remotes.py
@@ -1,10 +1,7 @@
 import pytest
 import numpy as np
-import time
 from os.path import join as pjoin
 from os import mkdir
-from random import randint
-import platform
 
 
 def test_list_all_remotes_works(repo):


### PR DESCRIPTION

## Motivation and Context
#### _Why is this change required? What problem does it solve?:_

allow variable size arraysets to have samples with dimensions of rank less than the schema shape.

#### _If it fixes an open issue, please link to the issue here:_

#109 

## Description
#### _Describe your changes in detail:_

The parsed record format for `hdf5` and `numpy` backends has been modified to support these new changes. The record format uses the markers `'x'` to indicate that a sample has been added to the arrayset which does not have some dimension, but fits within the container file for the schema. 

An example of the record dump for a variable shape arrayset of some schema (10, 10, 10) with two samples specifying the full number of dimensions and two samples being smaller. 
```
b'h:foohash1' b'00:hMSQPe$0 1*10 10 10'  <- fully specified sample
b'h:foohash2' b'00:hMSQPe$0 2*2 8 9' <- fully specified sample
b'h:foohash3' b'00:hMSQPe$0 3*x 5 5' <- sample shape (5, 5) into schema (10, 10, 10)
b'h:foohash4' b'00:hMSQPe$0 0*x x 3' <- sample shape (3,) into schema (10, 10, 10)
b's:cc1ffaef8f41' long binary
```

@hhsecond, can you take a look? This won't be a breaking change for repo's written in previous versions of hangar, as all prior samples must have had shapes which completely filled out the record format. Not sure if this will affect the ML dataloaders in any way? Also, let me know if you think any other test cases are needed. 

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Documentation update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Is this PR ready for review, or a work in progress?
- [ ] Ready for review
- [x] Work in progress

## How Has This Been Tested?
Put an `x` in the boxes that apply:
- [ ] Current tests cover modifications made
- [x] New tests have been added to the test suite
- [ ] Modifications were made to existing tests to support these changes
- [ ] Tests may be needed, but they are not included when the PR was proposed
- [ ] I don't know. Help!

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.rst)** document.
- [x] I have signed (or will sign when prompted) the tensorwork CLA.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## TODO:
- [ ] documentation updates
- [ ] ensure all necessary tests are included