### PR TITLE
return branch heads in repo log method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,11 @@ Change Log
 `In-Progress`_
 ==============
 
-TBD
+Bug Fixes
+---------
+
+* Programatic access to repository log contents now returns branch heads alongside other log info.
+  (`#125 <https://github.com/tensorwerk/hangar-py/pull/125>`__) `@rlizzo <https://github.com/rlizzo>`__
 
 
 `v0.3.0`_ (2019-09-10)

--- a/src/hangar/repository.py
+++ b/src/hangar/repository.py
@@ -363,11 +363,15 @@ class Repository(object):
             branchenv=self._env.branchenv,
             branch_name=branch,
             commit_hash=commit)
+        branchMap = dict(heads.commit_hash_to_branch_name_map(branchenv=self._env.branchenv))
 
         if return_contents:
+            for digest in list(branchMap.keys()):
+                if digest not in res['order']:
+                    del branchMap[digest]
+            res['branch_heads'] = branchMap
             return res
         else:
-            branchMap = heads.commit_hash_to_branch_name_map(branchenv=self._env.branchenv)
             g = graphing.Graph()
             g.show_nodes(dag=res['ancestors'],
                          spec=res['specs'],

--- a/src/hangar/utils.py
+++ b/src/hangar/utils.py
@@ -246,7 +246,7 @@ def folder_size(p: os.PathLike, *, recurse: bool = False) -> int:
     for entry in os.scandir(p):
         if entry.is_file(follow_symlinks=False):
             total += entry.stat().st_size
-        elif (recurse is True) and (entry.is_dir() is True):
+        elif (recurse is True) and (entry.is_dir(follow_symlinks=False) is True):
             total += folder_size(entry.path, recurse=True)
     return total
 


### PR DESCRIPTION
## Motivation and Context
#### _Why is this change required? What problem does it solve?:_

Add more useful branch info to log output

#### _If it fixes an open issue, please link to the issue here:_

- closes #123 

## Description
#### _Describe your changes in detail:_

`branch_heads` key now returned along side the rest of the info. 

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Documentation update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Is this PR ready for review, or a work in progress?
- [x] Ready for review
- [ ] Work in progress

## How Has This Been Tested?
Put an `x` in the boxes that apply:
- [ ] Current tests cover modifications made
- [x] New tests have been added to the test suite
- [ ] Modifications were made to existing tests to support these changes
- [ ] Tests may be needed, but they are not included when the PR was proposed
- [ ] I don't know. Help!

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.rst)** document.
- [x] I have signed (or will sign when prompted) the tensorwork CLA.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
