### PR TITLE
Branch Deletion

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,12 @@ Change Log
 `In-Progress`_
 ==============
 
+New Features
+------------
+
+* Added ability to delete branch names/pointers from a local repository via both API and CLI.
+  (`#128 <https://github.com/tensorwerk/hangar-py/pull/128>`__) `@rlizzo <https://github.com/rlizzo>`__
+
 Bug Fixes
 ---------
 

--- a/src/hangar/cli/cli.py
+++ b/src/hangar/cli/cli.py
@@ -279,9 +279,8 @@ def branch_create(repo: Repository, name, startpoint):
     else:
         base_commit = expand_short_commit_digest(repo._env.refenv, startpoint)
 
-    click.echo(f'BRANCH: ' +
-               repo.create_branch(name, base_commit=base_commit) +
-               f' HEAD: {base_commit}')
+    res = repo.create_branch(name, base_commit=base_commit)
+    click.echo(f'BRANCH: {res.name} HEAD: {res.digest}')
 
 
 # ---------------------------- Server Commands --------------------------------

--- a/src/hangar/records/commiting.py
+++ b/src/hangar/records/commiting.py
@@ -140,7 +140,7 @@ def get_commit_ancestors(refenv, commit_hash):
     Returns
     -------
     namedtuple
-        Namedtuple describing is_merge_commit, master_ancester, &
+        Namedtuple describing is_merge_commit, master_ancestor, &
         child_ancestor (in the even of merge commit)
 
     Raises
@@ -232,7 +232,7 @@ def get_commit_ref(refenv, commit_hash):
 
     Parameters
     ----------
-    refenv : lmdb.Envirionment`
+    refenv : lmdb.Environment`
         lmdb environment where the references are stored
     commit_hash : string
         hash of the commit to retrieve.
@@ -351,15 +351,15 @@ Methods to write new commits
 ----------------------------
 
 The functions below act to:
-    - Reading and formating all record data from the staging area.
+    - Reading and formatting all record data from the staging area.
     - Determining the ancestor(s) of the new commit
-    - Specify commit details (message, time, commiter-info, etc.)
+    - Specify commit details (message, time, committer-info, etc.)
     - Coordinate record hashing
     - Write the commit record
     - Update the branch head to point to the new commit hash
 """
 
-# ---------------- Functions to format the writen values of a commit --------------------
+# ---------------- Functions to format the written values of a commit --------------------
 
 
 def _commit_ancestors(branchenv: lmdb.Environment,
@@ -369,13 +369,13 @@ def _commit_ancestors(branchenv: lmdb.Environment,
                       dev_branch: str = '') -> DigestAndBytes:
     """Format the commit parent db value, finding HEAD commits automatically.
 
-    This method handles formating for both regular & merge commits through the
+    This method handles formatting for both regular & merge commits through the
     the keyword only arguments.
 
     Parameters
     ----------
     branchenv : lmdb.Environment
-        Lmdb envrionment where branch data is located. If not merge commit, head
+        Lmdb environment where branch data is located. If not merge commit, head
         branch and commit will be found.
     is_merge_commit : bool, optional
         If this is a merge commit or now, defaults to False
@@ -419,7 +419,7 @@ def _commit_spec(message: str, user: str, email: str) -> DigestAndBytes:
     message : string
         Commit message sent in by the user.
     user : str, optional
-        Name of the commiter
+        Name of the committer
     email : str, optional
         Email of the committer
 
@@ -469,7 +469,7 @@ def commit_records(message, branchenv, stageenv, refenv, repo_path,
     Parameters
     ----------
     message : string
-        Message the user accociates with what has been added, removed, or
+        Message the user associates with what has been added, removed, or
         changed in this commit. Must not be empty.
     branchenv : lmdb.Environment
         lmdb environment where branch records are stored.
@@ -523,7 +523,7 @@ def commit_records(message, branchenv, stageenv, refenv, repo_path,
     finally:
         TxnRegister().commit_writer_txn(refenv)
 
-    # possible seperate function
+    # possible separate function
     move_process_data_to_store(repo_path)
     if is_merge_commit is False:
         headBranchName = heads.get_staging_branch_head(branchenv)
@@ -539,7 +539,7 @@ def commit_records(message, branchenv, stageenv, refenv, repo_path,
 
 
 def replace_staging_area_with_commit(refenv, stageenv, commit_hash):
-    """DANGER ZONE: Delete the stage db and replace it with a copy of a commit environent.
+    """DANGER ZONE: Delete the stage db and replace it with a copy of a commit environment.
 
     .. warning::
 
@@ -577,12 +577,12 @@ def replace_staging_area_with_refs(stageenv, sorted_content):
 
     Parameters
     ----------
-    stageenv : lmdb.Enviornment
+    stageenv : lmdb.Environment
         staging area db to replace all data in.
     sorted_content : iterable of tuple
         iterable containing two-tuple of byte encoded record data to place in
         the stageenv db. index 0 -> db key; index 1 -> db val, it is assumed
-        that the order of the tuples is lexigraphically sorted by index 0
+        that the order of the tuples is lexicographically sorted by index 0
         values, if not, this will result in unknown behavior.
     """
     stagetxn = TxnRegister().begin_writer_txn(stageenv)
@@ -609,18 +609,18 @@ def move_process_data_to_store(repo_path: str, *, remote_operation: bool = False
     In process writes never directly access files in the data directory.
     Instead, when the file is created is is symlinked to either the remote data
     or stage data directory. All access is handled through this intermediate
-    symlink in order to prevent any ability to overwpackedeven if
-    there are major errors in the hash records). Once the write operation
-    packedor staging, or completion of fetch for remote), this
-    method is called to move the symlinks from the write enabled directory to
-    the (read only, fully-committed) storage dir.
+    symlink in order to prevent any ability to overwrite (even if there are
+    major errors in the hash records). Once the write operation is packed in
+    the staging or remote area, this method is called to move the symlinks from
+    the write enabled directory to the (read only, fully-committed) storage
+    dir.
 
     Parameters
     ----------
     repo_path : str
         path to the repository on dir
     remote_operation : bool, optional
-        If this operation is occuring from a remote fetch operation. (the
+        If this operation is occurring from a remote fetch operation. (the
         default is False, which means that all changes will occur in the
         staging area)
 
@@ -666,7 +666,7 @@ def move_process_data_to_store(repo_path: str, *, remote_operation: bool = False
 
 
 def list_all_commits(refenv):
-    """returns a list of all commits stored in the repostiory
+    """returns a list of all commits stored in the repository
 
     Parameters
     ----------

--- a/src/hangar/records/heads.py
+++ b/src/hangar/records/heads.py
@@ -19,13 +19,13 @@ Write operation enabled lock methods
 ------------------------------------
 
 Any operation which wants to interact with the main storage services in a
-write-enabled way must aquire a lock to perform the operation. See docstrings
+write-enabled way must acquire a lock to perform the operation. See docstrings
 below for more info
 """
 
 
 def writer_lock_held(branchenv):
-    """Check to see if the writer lock is free before attempting to aquire it.
+    """Check to see if the writer lock is free before attempting to acquire it.
 
     Parameters
     ----------
@@ -74,7 +74,7 @@ def acquire_writer_lock(branchenv, writer_uuid):
     -------
     bool
         success of the operation, which will be validated by the writer class as
-        a safety net incase the upstream in the event some user code trys to
+        a safety net incase the upstream in the event some user code tries to
         catch the exception.Z
 
     Raises
@@ -101,9 +101,9 @@ def acquire_writer_lock(branchenv, writer_uuid):
             success = True
         else:
             success = False
-            err = f'Cannot aquire the writer lock. Only one instance of a writer checkout '\
+            err = f'Cannot acquire the writer lock. Only one instance of a writer checkout '\
                 'can be active at a time. If the last checkout of this repository did '\
-                'not properly close, or a crash occured, the lock must be manually freed '\
+                'not properly close, or a crash occurred, the lock must be manually freed '\
                 'before another writer can be instantiated.'
             raise PermissionError(err)
     finally:
@@ -115,9 +115,9 @@ def acquire_writer_lock(branchenv, writer_uuid):
 def release_writer_lock(branchenv, writer_uuid):
     """Internal method to release a writer lock held by a specified uuid.
 
-    This method also accept the force-release sentinal by a caller in the
+    This method also accept the force-release sentinel by a caller in the
     writer_uuid field. If the writer_uuid does not match the lock value (and the
-    force sentinal is not used), then a runtime error will be thrown and no-op
+    force sentinel is not used), then a runtime error will be thrown and no-op
     performed
 
     Parameters
@@ -201,14 +201,14 @@ def create_branch(branchenv, name, base_commit) -> BranchHead:
     ValueError
         If the branch already exists, no-op and raise this.
     RuntimeError
-        If the repository does not have atleast one commit on the `default`
+        If the repository does not have at-least one commit on the `default`
         (ie. `master`) branch.
     """
     if base_commit is None:
         headBranch = get_staging_branch_head(branchenv)
         base_commit = get_branch_head_commit(branchenv, headBranch)
         if (headBranch == 'master') and (base_commit == ''):
-            msg = 'Atleast one commit must be made in the repository on the `default` '\
+            msg = 'At least one commit must be made in the repository on the `default` '\
                   '(`master`) branch before new branches can be created'
             raise RuntimeError(msg)
 
@@ -244,7 +244,7 @@ def remove_branch(branchenv: lmdb.Environment,
     name : str
         name of the branch which should be deleted.
     force_delete : bool, optional
-        If True, remove the branch pointer even if the changes are unmerged in
+        If True, remove the branch pointer even if the changes are un-merged in
         other branch histories. by default False
 
     Returns
@@ -279,7 +279,7 @@ def remove_branch(branchenv: lmdb.Environment,
 
     alive_branches.remove(name)
     if len(alive_branches) == 0:
-        msg = f'Not allowed to remove all branchs from a repository! '\
+        msg = f'Not allowed to remove all branches from a repository! '\
               f'Operation aborted without completing removal of branch: {name}'
         raise PermissionError(msg)
 
@@ -563,7 +563,7 @@ def add_remote(branchenv: lmdb.Environment, name: str, address: str) -> bool:
 
 
 def get_remote_address(branchenv: lmdb.Environment, name: str) -> str:
-    """Retieve the IO:PORT of the remote server for a given name
+    """Retrieve the IO:PORT of the remote server for a given name
 
     Parameters
     ----------

--- a/src/hangar/records/heads.py
+++ b/src/hangar/records/heads.py
@@ -177,7 +177,7 @@ Methods to interact with the branch head records
 # ---------------- branch creation and deletion operations ------------------------------
 
 
-def create_branch(branchenv, name, base_commit):
+def create_branch(branchenv, name, base_commit) -> BranchHead:
     """Internal operations used to create a branch.
 
     Parameters
@@ -192,8 +192,9 @@ def create_branch(branchenv, name, base_commit):
 
     Returns
     -------
-    str
-        Name of the branch which was created (if the operation was successful)
+    BranchHead
+        NamedTuple[str, str] with fields for `name` and `digest` of the branch
+        created (if the operation was successful)
 
     Raises
     ------
@@ -224,7 +225,7 @@ def create_branch(branchenv, name, base_commit):
     finally:
         TxnRegister().commit_writer_txn(branchenv)
 
-    return name
+    return BranchHead(name=name, digest=base_commit)
 
 
 def remove_branch(branchenv: lmdb.Environment,

--- a/src/hangar/records/parsing.py
+++ b/src/hangar/records/parsing.py
@@ -120,7 +120,7 @@ def repo_version_db_val_from_raw_val(v_spec: VersionSpec) -> bytes:
 
 
 def repo_version_raw_val_from_db_val(db_val: bytes) -> VersionSpec:
-    """determine software version of hangar repository is writter for.
+    """determine software version of hangar repository is written for.
 
     Parameters
     ----------

--- a/src/hangar/records/queries.py
+++ b/src/hangar/records/queries.py
@@ -164,7 +164,7 @@ class RecordQuery(object):
         """Find all data hashes contained within all arraysets
 
         Note: this method does not remove any duplicates which may be present,
-        if dedup is required, process it downstream
+        if de-dup is required, process it downstream
 
         Returns
         -------
@@ -179,7 +179,7 @@ class RecordQuery(object):
             all_hashes.update(data_val_rec)
         return all_hashes
 
-# ------------------------ processs arrayset data records -------------------------------
+# ------------------------ process arrayset data records ----------------------
 
     def arrayset_data_records(self, arrayset_name: str) -> Iterable[RawDataTuple]:
         """Returns the raw data record key and record values for a specific arrayset.
@@ -317,7 +317,7 @@ class RecordQuery(object):
         return all_schema_hashes
 
     def data_hash_to_schema_hash(self) -> Dict[str, str]:
-        """For all hashs in the commit, map sample hash to schema hash.
+        """For all hashes in the commit, map sample hash to schema hash.
 
         Returns
         -------

--- a/src/hangar/records/summarize.py
+++ b/src/hangar/records/summarize.py
@@ -17,7 +17,7 @@ def list_history(refenv, branchenv, branch_name=None, commit_hash=None):
     refenv : lmdb.Environment
         environment containing all repository commit data.
     branchenv : lmdb.Environment
-        environment contianing the current staging head branch and branch head
+        environment containing the current staging head branch and branch head
         commit hashes
     branch_name : string, optional
         if specified, get the history starting at the head commit of this named

--- a/src/hangar/utils.py
+++ b/src/hangar/utils.py
@@ -161,7 +161,7 @@ def is_ascii(str_data: str) -> bool:
     """
     try:
         str_data.encode('ascii')
-    except UnicodeEncodeError:
+    except (UnicodeEncodeError, AttributeError):
         return False
     return True
 

--- a/tests/test_branching.py
+++ b/tests/test_branching.py
@@ -210,7 +210,20 @@ def test_delete_branch_raises_permission_error_if_branch_requested_is_staging_he
     thirdDigest = co.commit('third')
     co.close()
 
-    # checkout master so staging area is not on branch
     with pytest.raises(PermissionError):
         repo.remove_branch('testdelete')
     assert repo.list_branches() == ['master', 'testdelete']
+
+
+def test_delete_branch_raises_permission_error_if_only_one_branch_left(written_repo):
+    repo = written_repo
+    co = repo.checkout(write=True)
+    co.metadata['foo'] = 'bar'
+    masterHEAD = co.commit('second')
+    co.close()
+
+
+    assert repo.list_branches() == ['master']
+    with pytest.raises(PermissionError):
+        repo.remove_branch('master')
+    assert repo.list_branches() == ['master']

--- a/tests/test_branching.py
+++ b/tests/test_branching.py
@@ -1,0 +1,216 @@
+import pytest
+
+
+def test_create_branch_fails_invalid_name(written_repo):
+    # TODO: really need property based test for this stuff...
+    # Should only contain ascii_letters, ascii_numbers,
+    # and '-', '_', '.' characters (no whitespace)
+    repo = written_repo
+    with pytest.raises(ValueError):
+        repo.create_branch('dummy branch')
+    with pytest.raises(ValueError):
+        repo.create_branch('origin/master')
+    with pytest.raises(ValueError):
+        repo.create_branch('\nmaster')
+    with pytest.raises(ValueError):
+        repo.create_branch('\\master')
+    with pytest.raises(ValueError):
+        repo.create_branch('master ')
+    with pytest.raises(ValueError):
+        repo.create_branch(1412)
+    with pytest.raises(ValueError):
+        repo.create_branch('foo !')
+    with pytest.raises(ValueError):
+        repo.create_branch('foo@')
+    with pytest.raises(ValueError):
+        repo.create_branch('foo#')
+    with pytest.raises(ValueError):
+        repo.create_branch('foo$')
+    with pytest.raises(ValueError):
+        repo.create_branch('(foo)')
+
+
+def test_list_branches_only_reports_master_upon_initialization(repo):
+    branches = repo.list_branches()
+    assert branches == ['master']
+
+
+def test_cannot_create_new_branch_from_initialized_repo_with_no_commits(repo):
+    with pytest.raises(RuntimeError):
+        repo.create_branch('testbranch')
+
+
+def test_can_create_new_branch_from_repo_with_one_commit(repo):
+    co = repo.checkout(write=True)
+    co.metadata['foo'] = 'bar'
+    expected_digest = co.commit('first')
+    co.close()
+
+    branchRes = repo.create_branch('testbranch')
+
+    assert branchRes.name == 'testbranch'
+    assert branchRes.digest == expected_digest
+
+
+def test_cannot_duplicate_branch_name(written_repo):
+    written_repo.create_branch('testbranch')
+    with pytest.raises(ValueError):
+        written_repo.create_branch('testbranch')
+
+
+def test_create_multiple_branches_different_name_same_commit(written_repo):
+    b1 = written_repo.create_branch('testbranch1')
+    b2 = written_repo.create_branch('testbranch2')
+    b3 = written_repo.create_branch('testbranch3')
+
+    assert b1.digest == b2.digest
+    assert b2.digest == b3.digest
+    assert b3.digest == b1.digest
+    assert written_repo.list_branches() == ['master', 'testbranch1', 'testbranch2', 'testbranch3']
+
+
+def test_create_branch_by_specifying_base_commit(written_repo):
+
+    repo = written_repo
+    co = repo.checkout(write=True)
+    first_digest = co.commit_hash
+    co.metadata['foo'] = 'bar'
+    second_digest = co.commit('second')
+    co.metadata['hello'] = 'world'
+    third_digest = co.commit('third')
+    co.metadata['zen'] = 'python'
+    fourth_digest = co.commit('fourth')
+    co.close()
+
+    assert repo.list_branches() == ['master']
+
+    secBranch = repo.create_branch('dev-second', base_commit=second_digest)
+    assert secBranch.name == 'dev-second'
+    assert secBranch.digest == second_digest
+
+    co = repo.checkout(branch='dev-second')
+    assert len(co.metadata) == 1
+    assert co.metadata['foo'] == 'bar'
+    co.close()
+
+
+def test_remove_branch_works_when_commits_align(written_repo):
+    repo = written_repo
+    co = repo.checkout(write=True)
+    co.metadata['foo'] = 'bar'
+    masterHEAD = co.commit('second')
+    co.close()
+    repo.create_branch('testdelete')
+
+    assert repo.list_branches() == ['master', 'testdelete']
+
+    removedBranch = repo.remove_branch('testdelete')
+    assert removedBranch.name == 'testdelete'
+    assert removedBranch.digest == masterHEAD
+    assert repo.list_branches() == ['master']
+
+
+def test_delete_branch_raises_runtime_error_when_history_not_merged(written_repo):
+    repo = written_repo
+    co = repo.checkout(write=True)
+    co.metadata['foo'] = 'bar'
+    masterHEAD = co.commit('second')
+    co.close()
+
+    repo.create_branch('testdelete')
+    co = repo.checkout(write=True, branch='testdelete')
+    co.metadata['hello'] = 'world'
+    thirdDigest = co.commit('third')
+    co.close()
+
+    # checkout master so staging area is not on branch
+    co = repo.checkout(write=True, branch='master')
+    co.close()
+
+    assert repo.list_branches() == ['master', 'testdelete']
+    with pytest.raises(RuntimeError):
+        repo.remove_branch('testdelete')
+
+
+def test_delete_branch_completes_when_history_not_merged_but_force_option_set(written_repo):
+    repo = written_repo
+    co = repo.checkout(write=True)
+    co.metadata['foo'] = 'bar'
+    masterHEAD = co.commit('second')
+    co.close()
+
+    repo.create_branch('testdelete')
+    co = repo.checkout(write=True, branch='testdelete')
+    co.metadata['hello'] = 'world'
+    thirdDigest = co.commit('third')
+    co.close()
+
+    # checkout master so staging area is not on branch
+    co = repo.checkout(write=True, branch='master')
+    co.close()
+    assert repo.list_branches() == ['master', 'testdelete']
+
+    removedBranch = repo.remove_branch('testdelete', force_delete=True)
+    assert removedBranch.name == 'testdelete'
+    assert removedBranch.digest == thirdDigest
+    assert repo.list_branches() == ['master']
+
+
+def test_delete_branch_raises_value_error_if_invalid_branch_name(written_repo):
+    repo = written_repo
+    co = repo.checkout(write=True)
+    co.metadata['foo'] = 'bar'
+    masterHEAD = co.commit('second')
+    co.close()
+
+    repo.create_branch('testdelete')
+    co = repo.checkout(write=True, branch='testdelete')
+    co.metadata['hello'] = 'world'
+    thirdDigest = co.commit('third')
+    co.close()
+
+    assert repo.list_branches() == ['master', 'testdelete']
+    with pytest.raises(ValueError):
+        repo.remove_branch('doesnotexist')
+    with pytest.raises(ValueError):
+        repo.remove_branch('origin/master')
+
+
+def test_delete_branch_raises_permission_error_if_writer_lock_held(written_repo):
+    repo = written_repo
+    co = repo.checkout(write=True)
+    co.metadata['foo'] = 'bar'
+    masterHEAD = co.commit('second')
+    co.close()
+
+    repo.create_branch('testdelete')
+    co = repo.checkout(write=True, branch='testdelete')
+    co.metadata['hello'] = 'world'
+    thirdDigest = co.commit('third')
+    co.close()
+
+    # checkout master so staging area is not on branch
+    co = repo.checkout(write=True, branch='master')
+    with pytest.raises(PermissionError):
+        repo.remove_branch('testdelete')
+    assert repo.list_branches() == ['master', 'testdelete']
+    co.close()
+
+
+def test_delete_branch_raises_permission_error_if_branch_requested_is_staging_head(written_repo):
+    repo = written_repo
+    co = repo.checkout(write=True)
+    co.metadata['foo'] = 'bar'
+    masterHEAD = co.commit('second')
+    co.close()
+
+    repo.create_branch('testdelete')
+    co = repo.checkout(write=True, branch='testdelete')
+    co.metadata['hello'] = 'world'
+    thirdDigest = co.commit('third')
+    co.close()
+
+    # checkout master so staging area is not on branch
+    with pytest.raises(PermissionError):
+        repo.remove_branch('testdelete')
+    assert repo.list_branches() == ['master', 'testdelete']

--- a/tests/test_remotes.py
+++ b/tests/test_remotes.py
@@ -152,7 +152,7 @@ def test_server_push_second_branch_with_new_commit(server_instance, repo,
 
     branch = repo.create_branch('testbranch')
     for cIdx in range(nDevCommits):
-        co = repo.checkout(write=True, branch=branch)
+        co = repo.checkout(write=True, branch=branch.name)
         devSampList = []
         with co.arraysets['writtenaset'] as d:
             for prevKey in list(d.keys())[1:]:
@@ -165,8 +165,8 @@ def test_server_push_second_branch_with_new_commit(server_instance, repo,
         devCmtList.append((cmt, devSampList))
         co.close()
 
-    push2 = repo.remote.push('origin', branch)
-    assert push2 == branch
+    push2 = repo.remote.push('origin', branch.name)
+    assert push2 == branch.name
 
 
 @pytest.mark.parametrize('nMasterCommits,nMasterSamples', [[1, 4], [10, 10]])
@@ -205,7 +205,7 @@ def test_server_push_second_branch_with_new_commit_then_clone_partial_fetch(
     devCmtList = []
     branch = repo.create_branch('testbranch')
     for cIdx in range(nDevCommits):
-        co = repo.checkout(write=True, branch=branch)
+        co = repo.checkout(write=True, branch=branch.name)
         devSampList = []
         with co.arraysets['writtenaset'] as d:
             for prevKey in list(d.keys())[1:]:
@@ -218,9 +218,9 @@ def test_server_push_second_branch_with_new_commit_then_clone_partial_fetch(
         devCmtList.append((cmt, devSampList))
         co.close()
 
-    push2 = repo.remote.push('origin', branch)
-    assert push2 == branch
-    branchHist = list_history(repo._env.refenv, repo._env.branchenv, branch_name=branch)
+    push2 = repo.remote.push('origin', branch.name)
+    assert push2 == branch.name
+    branchHist = list_history(repo._env.refenv, repo._env.branchenv, branch_name=branch.name)
 
     # Clone test (master branch)
     new_tmpdir = pjoin(managed_tmpdir, 'new')
@@ -248,9 +248,9 @@ def test_server_push_second_branch_with_new_commit_then_clone_partial_fetch(
     assert cloneMasterHist == masterHist
 
     # Fetch test
-    fetch = newRepo.remote.fetch('origin', branch=branch)
-    assert fetch == f'origin/{branch}'
-    assert newRepo.list_branches() == ['master', 'origin/master', f'origin/{branch}']
+    fetch = newRepo.remote.fetch('origin', branch=branch.name)
+    assert fetch == f'origin/{branch.name}'
+    assert newRepo.list_branches() == ['master', 'origin/master', f'origin/{branch.name}']
     for cmt, sampList in devCmtList:
         # newRepo.remote.fetch_data('origin', commit=cmt)
         with pytest.warns(UserWarning):
@@ -269,7 +269,7 @@ def test_server_push_second_branch_with_new_commit_then_clone_partial_fetch(
                 shouldNotExist = nco.arraysets['writtenaset'][sIdx]
             # assert np.allclose(nco.arraysets['writtenaset'][str(sIdx)], samp)
         nco.close()
-    cloneBranchHist = list_history(newRepo._env.refenv, newRepo._env.branchenv, branch_name=f'origin/{branch}')
+    cloneBranchHist = list_history(newRepo._env.refenv, newRepo._env.branchenv, branch_name=f'origin/{branch.name}')
     assert cloneBranchHist == branchHist
     newRepo._env._close_environments()
 
@@ -354,7 +354,7 @@ def test_server_push_two_branch_then_clone_fetch_data_options(
     devCmts = masterCmts.copy()
     branch = repo.create_branch('testbranch')
     for cIdx in range(nDevCommits):
-        co = repo.checkout(write=True, branch=branch)
+        co = repo.checkout(write=True, branch=branch.name)
         devSampList1 = []
         devSampList2 = []
         with co.arraysets['writtenaset'] as d, co.arraysets['_two'] as dd:
@@ -373,9 +373,9 @@ def test_server_push_two_branch_then_clone_fetch_data_options(
         devCmts[cmt] = (devSampList1, devSampList2)
         co.close()
 
-    push2 = repo.remote.push('origin', branch)
-    assert push2 == branch
-    branchHist = list_history(repo._env.refenv, repo._env.branchenv, branch_name=branch)
+    push2 = repo.remote.push('origin', branch.name)
+    assert push2 == branch.name
+    branchHist = list_history(repo._env.refenv, repo._env.branchenv, branch_name=branch.name)
 
     # -------------------------- end setup ------------------------------------
 
@@ -384,9 +384,9 @@ def test_server_push_two_branch_then_clone_fetch_data_options(
     mkdir(new_tmpdir)
     newRepo = Repository(path=new_tmpdir, exists=False)
     newRepo.clone('Test User', 'tester@foo.com', server_instance, remove_old=True)
-    newRepo.remote.fetch('origin', branch=branch)
+    newRepo.remote.fetch('origin', branch=branch.name)
     newRepo.create_branch('testbranch', base_commit=branchHist['head'])
-    assert newRepo.list_branches() == ['master', 'origin/master', f'origin/{branch}', branch]
+    assert newRepo.list_branches() == ['master', 'origin/master', f'origin/{branch.name}', branch.name]
 
     # ------------------ format arguments dependingon options -----------------
 

--- a/tests/test_visualizations.py
+++ b/tests/test_visualizations.py
@@ -375,7 +375,7 @@ def test_repo_log_return_contents_correct_default_args(repo):
     ancestor_branch = repo.create_branch('ancestor', base_commit=ancestor_digest)
     dev_branch = repo.create_branch('dev', base_commit=ancestor_digest)
 
-    co = repo.checkout(write=True, branch=dev_branch)
+    co = repo.checkout(write=True, branch=dev_branch.name)
     co.metadata['zen'] = 'of python'
     dev_head = co.commit('third on test')
     co.close()
@@ -399,8 +399,8 @@ def test_repo_log_return_contents_correct_default_args(repo):
     assert log['order'] == [dev_head, ancestor_digest]
 
     assert len(log['branch_heads']) == 2
-    assert log['branch_heads'][ancestor_digest] == [ancestor_branch]
-    assert log['branch_heads'][dev_head] == [dev_branch]
+    assert log['branch_heads'][ancestor_digest] == [ancestor_branch.name]
+    assert log['branch_heads'][dev_head] == [dev_branch.name]
 
 
 def test_repo_log_return_contents_correct_when_specify_branch_name(repo):
@@ -415,7 +415,7 @@ def test_repo_log_return_contents_correct_when_specify_branch_name(repo):
     ancestor_branch = repo.create_branch('ancestor', base_commit=ancestor_digest)
     dev_branch = repo.create_branch('dev', base_commit=ancestor_digest)
 
-    co = repo.checkout(write=True, branch=dev_branch)
+    co = repo.checkout(write=True, branch=dev_branch.name)
     co.metadata['zen'] = 'of python'
     dev_head = co.commit('third on test')
     co.close()
@@ -439,7 +439,7 @@ def test_repo_log_return_contents_correct_when_specify_branch_name(repo):
     assert log['order'] == [master_head, ancestor_digest]
 
     assert len(log['branch_heads']) == 2
-    assert log['branch_heads'][ancestor_digest] == [ancestor_branch]
+    assert log['branch_heads'][ancestor_digest] == [ancestor_branch.name]
     assert log['branch_heads'][master_head] == ['master']
 
 
@@ -455,7 +455,7 @@ def test_repo_log_return_contents_correct_when_specify_digest(repo):
     ancestor_branch = repo.create_branch('ancestor', base_commit=ancestor_digest)
     dev_branch = repo.create_branch('dev', base_commit=ancestor_digest)
 
-    co = repo.checkout(write=True, branch=dev_branch)
+    co = repo.checkout(write=True, branch=dev_branch.name)
     co.metadata['zen'] = 'of python'
     dev_head = co.commit('third on test')
     co.close()
@@ -479,5 +479,5 @@ def test_repo_log_return_contents_correct_when_specify_digest(repo):
     assert log['order'] == [master_head, ancestor_digest]
 
     assert len(log['branch_heads']) == 2
-    assert log['branch_heads'][ancestor_digest] == [ancestor_branch]
+    assert log['branch_heads'][ancestor_digest] == [ancestor_branch.name]
     assert log['branch_heads'][master_head] == ['master']


### PR DESCRIPTION
## Motivation and Context
#### _Why is this change required? What problem does it solve?:_

Allow for the ability to remove the pointers to local branches. 

#### _If it fixes an open issue, please link to the issue here:_

* will close #80 

## Description
#### _Describe your changes in detail:_

See [`Repository.remove_branch()`](https://github.com/tensorwerk/hangar-py/pull/128/files#diff-bd186efcaa89e36f1b183835767d0085R482-R559) docstrings for overview of utility & considerations taken. 

The `create_branch()` method was updated to return same results as `remove_branch()` (now yielding both the subject branchs` name as well as its referent commit digest). Appropriate modifications were made to the test suite to adapt to (and test) this behavior, and the "branch modification" methods were given their own test module for future clarity as we expand on their abilities. 

I am currently working on adding analagous methods to the `CLI`, and will push those before this is merged.

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Documentation update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Is this PR ready for review, or a work in progress?
- [x] Ready for review
- [x] Work in progress

## How Has This Been Tested?
Put an `x` in the boxes that apply:
- [ ] Current tests cover modifications made
- [x] New tests have been added to the test suite
- [x] Modifications were made to existing tests to support these changes
- [ ] Tests may be needed, but they are not included when the PR was proposed
- [ ] I don't know. Help!

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.rst)** document.
- [x] I have signed (or will sign when prompted) the tensorwork CLA.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@hhsecond, let me know what you think. 