### PR TITLE
local data only arrayset iteration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,14 @@ New Features
 
 * Added ability to delete branch names/pointers from a local repository via both API and CLI.
   (`#128 <https://github.com/tensorwerk/hangar-py/pull/128>`__) `@rlizzo <https://github.com/rlizzo>`__
+* Added ``local`` keyword arg to arrayset key/value iterators to return only locally available samples
+  (`#131 <https://github.com/tensorwerk/hangar-py/pull/131>`__) `@rlizzo <https://github.com/rlizzo>`__
+
+Improvements
+------------
+
+* Removed ``msgpack`` and ``pyyaml`` dependencies. Cleaned up and improved remote client/server code.
+  (`#130 <https://github.com/tensorwerk/hangar-py/pull/130>`__) `@rlizzo <https://github.com/rlizzo>`__
 
 Bug Fixes
 ---------

--- a/src/hangar/backends/__init__.py
+++ b/src/hangar/backends/__init__.py
@@ -1,5 +1,6 @@
 from .selection import BACKEND_ACCESSOR_MAP
 from .selection import backend_decoder
 from .selection import backend_from_heuristics
+from .selection import is_local_backend
 
-__all__ = ['BACKEND_ACCESSOR_MAP', 'backend_decoder', 'backend_from_heuristics']
+__all__ = ['BACKEND_ACCESSOR_MAP', 'backend_decoder', 'backend_from_heuristics', 'is_local_backend']

--- a/src/hangar/backends/selection.py
+++ b/src/hangar/backends/selection.py
@@ -180,3 +180,10 @@ def backend_from_heuristics(array: np.ndarray) -> str:
         backend = '00'
 
     return backend
+
+
+def is_local_backend(be_loc: _DataHashSpecs) -> bool:
+    if be_loc[0].startswith('5'):
+        return False
+    else:
+        return True

--- a/src/hangar/checkout.py
+++ b/src/hangar/checkout.py
@@ -300,7 +300,7 @@ class ReaderCheckout(object):
 
             Names(s) of the samples to query
 
-        except_missing: bool, **KWARG ONLY
+        except_missing: bool, **KWARG ONLY**
 
             If False, will not throw exceptions on missing sample key value.
             Will raise KeyError if True and missing key found.
@@ -884,7 +884,7 @@ class WriterCheckout(object):
 
             Names(s) of the samples to query
 
-        except_missing: bool, **KWARG ONLY
+        except_missing: bool, **KWARG ONLY**
 
             If False, will not throw exceptions on missing sample key value.
             Will raise KeyError if True and missing key found.


### PR DESCRIPTION
## Motivation and Context
#### _Why is this change required? What problem does it solve?:_

added ability to iterate over keys, values, items of an arrayset with only locally available data.

## Description
#### _Describe your changes in detail:_

added optional `local` argument to Arrayset `.keys()`, `.values()`, `.items()` methods. If set True, only return elements which exist on the local disk (not on a remote server). Default is False, which returns all samples recorded in the commit. This keeps the same behavior as previous uses of these methods.  

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Documentation update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Is this PR ready for review, or a work in progress?
- [x] Ready for review
- [ ] Work in progress

## How Has This Been Tested?
Put an `x` in the boxes that apply:
- [ ] Current tests cover modifications made
- [x] New tests have been added to the test suite
- [ ] Modifications were made to existing tests to support these changes
- [ ] Tests may be needed, but they are not included when the PR was proposed
- [ ] I don't know. Help!

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.rst)** document.
- [x] I have signed (or will sign when prompted) the tensorwork CLA.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
