### PR TITLE
BUG FIX: Zero Valued Arrays Hash Incorrectly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ pip-log.txt
 nosetests.xml
 coverage.xml
 htmlcov
+.hypothesis
 
 # Translations
 *.mo

--- a/src/hangar/arrayset.py
+++ b/src/hangar/arrayset.py
@@ -9,6 +9,7 @@ import json
 
 import lmdb
 import numpy as np
+import struct
 
 from .backends import BACKEND_ACCESSOR_MAP
 from .backends import backend_decoder
@@ -765,7 +766,9 @@ class ArraysetDataWriter(ArraysetDataReader):
             if tmpconman:
                 self.__enter__()
 
-            full_hash = hashlib.blake2b(data.tobytes(), digest_size=20).hexdigest()
+            hasher = hashlib.blake2b(data, digest_size=20)
+            hasher.update(struct.pack(f'<{len(data.shape)}Q', *data.shape))
+            full_hash = hasher.hexdigest()
             hashKey = hash_data_db_key_from_raw_key(full_hash)
 
             # check if data record already exists with given key

--- a/src/hangar/arrayset.py
+++ b/src/hangar/arrayset.py
@@ -767,7 +767,7 @@ class ArraysetDataWriter(ArraysetDataReader):
                 self.__enter__()
 
             hasher = hashlib.blake2b(data, digest_size=20)
-            hasher.update(struct.pack(f'<{len(data.shape)}Q', *data.shape))
+            hasher.update(struct.pack(f'<{len(data.shape)}QB', *data.shape, data.dtype.num))
             full_hash = hasher.hexdigest()
             hashKey = hash_data_db_key_from_raw_key(full_hash)
 

--- a/src/hangar/remote/client.py
+++ b/src/hangar/remote/client.py
@@ -353,7 +353,9 @@ class HangarClient(object):
         for record in unpacked_records:
             data = chunks.deserialize_record(record)
             hasher = hashlib.blake2b(data.array, digest_size=20)
-            hasher.update(struct.pack(f'<{len(data.shape)}Q', *data.shape))
+            hasher.update(
+                struct.pack(f'<{len(data.array.shape)}QB', *data.array.shape,
+                            data.array.dtype.num))
             received_hash = hasher.hexdigest()
             if received_hash != data.digest:
                 raise RuntimeError(f'MANGLED! got: {received_hash} != requested: {data.digest}')

--- a/src/hangar/remote/server.py
+++ b/src/hangar/remote/server.py
@@ -8,6 +8,7 @@ from concurrent import futures
 from os.path import join as pjoin
 import shutil
 import configparser
+import struct
 
 import blosc
 import grpc
@@ -366,7 +367,9 @@ class HangarServer(hangar_service_pb2_grpc.HangarServiceServicer):
         for record in unpacked_records:
             data = chunks.deserialize_record(record)
             schema_hash = data.schema
-            received_hash = hashlib.blake2b(data.array.tobytes(), digest_size=20).hexdigest()
+            hasher = hashlib.blake2b(data.array, digest_size=20)
+            hasher.update(struct.pack(f'<{len(data.shape)}Q', *data.shape))
+            received_hash = hasher.hexdigest()
             if received_hash != data.digest:
                 msg = f'HASH MANGLED, received: {received_hash} != expected digest: {data.digest}'
                 context.set_details(msg)

--- a/src/hangar/remote/server.py
+++ b/src/hangar/remote/server.py
@@ -368,7 +368,9 @@ class HangarServer(hangar_service_pb2_grpc.HangarServiceServicer):
             data = chunks.deserialize_record(record)
             schema_hash = data.schema
             hasher = hashlib.blake2b(data.array, digest_size=20)
-            hasher.update(struct.pack(f'<{len(data.shape)}Q', *data.shape))
+            hasher.update(
+                struct.pack(f'<{len(data.array.shape)}QB', *data.array.shape,
+                            data.array.dtype.num))
             received_hash = hasher.hexdigest()
             if received_hash != data.digest:
                 msg = f'HASH MANGLED, received: {received_hash} != expected digest: {data.digest}'

--- a/tests/property_based/conftest.py
+++ b/tests/property_based/conftest.py
@@ -1,0 +1,38 @@
+import pytest
+
+import numpy as np
+
+from hangar import Repository
+
+
+backend_params = ['00', '10']
+
+
+@pytest.fixture(params=backend_params)
+def variable_shape_repo_co_float32(managed_tmpdir, request) -> Repository:
+    repo_obj = Repository(path=managed_tmpdir, exists=False)
+    repo_obj.init(user_name='tester', user_email='foo@test.bar', remove_old=True)
+    co = repo_obj.checkout(write=True)
+    co.arraysets.init_arrayset(name='writtenaset',
+                               shape=(10, 10, 10, 10),
+                               dtype=np.float32,
+                               variable_shape=True,
+                               backend_opts=request.param)
+    yield co
+    co.close()
+    repo_obj._env._close_environments()
+
+
+@pytest.fixture(params=backend_params)
+def variable_shape_repo_co_uint8(managed_tmpdir, request) -> Repository:
+    repo_obj = Repository(path=managed_tmpdir, exists=False)
+    repo_obj.init(user_name='tester', user_email='foo@test.bar', remove_old=True)
+    co = repo_obj.checkout(write=True)
+    co.arraysets.init_arrayset(name='writtenaset',
+                               shape=(10, 10, 10, 10),
+                               dtype=np.uint8,
+                               variable_shape=True,
+                               backend_opts=request.param)
+    yield co
+    co.close()
+    repo_obj._env._close_environments()

--- a/tests/property_based/conftest.py
+++ b/tests/property_based/conftest.py
@@ -9,6 +9,22 @@ backend_params = ['00', '10']
 
 
 @pytest.fixture(params=backend_params)
+def fixed_shape_repo_co_float32(managed_tmpdir, request) -> Repository:
+    repo_obj = Repository(path=managed_tmpdir, exists=False)
+    repo_obj.init(user_name='tester', user_email='foo@test.bar', remove_old=True)
+    co = repo_obj.checkout(write=True)
+    co.arraysets.init_arrayset(name='writtenaset',
+                               shape=(10, 10, 10, 10),
+                               dtype=np.float32,
+                               variable_shape=True,
+                               backend_opts=request.param)
+    yield co
+    co.close()
+    repo_obj._env._close_environments()
+
+
+
+@pytest.fixture(params=backend_params)
 def variable_shape_repo_co_float32(managed_tmpdir, request) -> Repository:
     repo_obj = Repository(path=managed_tmpdir, exists=False)
     repo_obj.init(user_name='tester', user_email='foo@test.bar', remove_old=True)
@@ -33,6 +49,16 @@ def variable_shape_repo_co_uint8(managed_tmpdir, request) -> Repository:
                                dtype=np.uint8,
                                variable_shape=True,
                                backend_opts=request.param)
+    yield co
+    co.close()
+    repo_obj._env._close_environments()
+
+
+@pytest.fixture()
+def w_metadata_co(managed_tmpdir) -> Repository:
+    repo_obj = Repository(path=managed_tmpdir, exists=False)
+    repo_obj.init(user_name='tester', user_email='foo@test.bar', remove_old=True)
+    co = repo_obj.checkout(write=True)
     yield co
     co.close()
     repo_obj._env._close_environments()

--- a/tests/property_based/test_pbt_arrayset.py
+++ b/tests/property_based/test_pbt_arrayset.py
@@ -9,37 +9,53 @@ from hypothesis.extra import numpy as npst
 
 
 st_valid_names = st.text(
-    min_size=1, max_size=64, alphabet=string.ascii_letters + string.digits + '_-.')
-st_valid_ints = st.integers(min_value=0)
+    min_size=1, max_size=32, alphabet=string.ascii_letters + string.digits + '_-.')
+st_valid_ints = st.integers(min_value=0, max_value=999_999)
 st_valid_keys = st.one_of(st_valid_ints, st_valid_names)
 
 
-valid_arrays_fixed = npst.arrays(np.float64,
-                                 shape=(5, 7),
-                                 elements=st.floats(allow_nan=False,
+valid_arrays_fixed = npst.arrays(np.float32,
+                                 shape=(10, 10, 10, 10),
+                                 fill=st.floats(min_value=-100000000,
+                                                max_value=100000000,
+                                                allow_nan=False,
+                                                allow_infinity=False,
+                                                width=32),
+                                 elements=st.floats(min_value=-100000000,
+                                                    max_value=100000000,
+                                                    allow_nan=False,
                                                     allow_infinity=False,
-                                                    width=64))
+                                                    width=32))
 
 
 @given(key=st_valid_keys, val=valid_arrays_fixed)
-@settings(max_examples=500)
-def test_arrayset_fixed_key_values(key, val, w_checkout):
-    w_checkout.arraysets['writtenaset'][key] = val
-    out = w_checkout.arraysets['writtenaset'][key]
+@settings(max_examples=200, deadline=3000.0)
+def test_arrayset_fixed_key_values(key, val, fixed_shape_repo_co_float32):
+    co = fixed_shape_repo_co_float32
+    co.arraysets['writtenaset'][key] = val
+    out = co.arraysets['writtenaset'][key]
     assert out.dtype == val.dtype
-    assert np.allclose(out, val) is True
+    assert out.shape == val.shape
+    assert np.allclose(out, val)
 
 
 valid_shapes_var = npst.array_shapes(min_dims=4, max_dims=4, min_side=1, max_side=10)
 valid_arrays_var_float32 = npst.arrays(np.float32,
                                        shape=valid_shapes_var,
-                                       elements=st.floats(allow_nan=False,
+                                       fill=st.floats(min_value=-100000000,
+                                                      max_value=100000000,
+                                                      allow_nan=False,
+                                                      allow_infinity=False,
+                                                      width=32),
+                                       elements=st.floats(min_value=-100000000,
+                                                          max_value=100000000,
+                                                          allow_nan=False,
                                                           allow_infinity=False,
                                                           width=32))
 
 
 @given(key=st_valid_keys, val=valid_arrays_var_float32)
-@settings(max_examples=500)
+@settings(max_examples=200, deadline=3000.0)
 def test_arrayset_variable_shape_float32(key, val, variable_shape_repo_co_float32):
     co = variable_shape_repo_co_float32
     assert co.arraysets['writtenaset'].variable_shape is True
@@ -50,11 +66,13 @@ def test_arrayset_variable_shape_float32(key, val, variable_shape_repo_co_float3
     assert np.allclose(out, val)
 
 
-valid_arrays_var_uint8 = npst.arrays(np.uint8, shape=valid_shapes_var)
+valid_arrays_var_uint8 = npst.arrays(np.uint8,
+                                     shape=valid_shapes_var,
+                                     fill=st.integers(min_value=0, max_value=255))
 
 
 @given(key=st_valid_keys, val=valid_arrays_var_uint8)
-@settings(max_examples=500)
+@settings(max_examples=200)
 def test_arrayset_variable_shape_uint8(key, val, variable_shape_repo_co_uint8):
     co = variable_shape_repo_co_uint8
     assert co.arraysets['writtenaset'].variable_shape is True

--- a/tests/property_based/test_pbt_arrayset.py
+++ b/tests/property_based/test_pbt_arrayset.py
@@ -1,0 +1,64 @@
+import pytest
+import numpy as np
+
+import string
+
+from hypothesis import given, settings
+import hypothesis.strategies as st
+from hypothesis.extra import numpy as npst
+
+
+st_valid_names = st.text(
+    min_size=1, max_size=64, alphabet=string.ascii_letters + string.digits + '_-.')
+st_valid_ints = st.integers(min_value=0)
+st_valid_keys = st.one_of(st_valid_ints, st_valid_names)
+
+
+valid_arrays_fixed = npst.arrays(np.float64,
+                                 shape=(5, 7),
+                                 elements=st.floats(allow_nan=False,
+                                                    allow_infinity=False,
+                                                    width=64))
+
+
+@given(key=st_valid_keys, val=valid_arrays_fixed)
+def test_arrayset_fixed_key_values(key, val, w_checkout):
+    w_checkout.arraysets['writtenaset'][key] = val
+    out = w_checkout.arraysets['writtenaset'][key]
+    assert out.dtype == val.dtype
+    assert np.allclose(out, val) is True
+
+
+valid_shapes_var = npst.array_shapes(min_dims=4, max_dims=4, min_side=1, max_side=10)
+valid_arrays_var_float32 = npst.arrays(np.float32,
+                                       shape=valid_shapes_var,
+                                       elements=st.floats(allow_nan=False,
+                                                          allow_infinity=False,
+                                                          width=32))
+
+
+@given(key=st_valid_keys, val=valid_arrays_var_float32)
+@settings(max_examples=500)
+def test_arrayset_variable_shape_float32(key, val, variable_shape_repo_co_float32):
+    co = variable_shape_repo_co_float32
+    assert co.arraysets['writtenaset'].variable_shape is True
+    co.arraysets['writtenaset'][key] = val
+    out = co.arraysets['writtenaset'][key]
+    assert out.dtype == val.dtype
+    assert out.shape == val.shape
+    assert np.allclose(out, val)
+
+
+valid_arrays_var_uint8 = npst.arrays(np.uint8, shape=valid_shapes_var)
+
+
+@given(key=st_valid_keys, val=valid_arrays_var_uint8)
+@settings(max_examples=500)
+def test_arrayset_variable_shape_uint8(key, val, variable_shape_repo_co_uint8):
+    co = variable_shape_repo_co_uint8
+    assert co.arraysets['writtenaset'].variable_shape is True
+    co.arraysets['writtenaset'][key] = val
+    out = co.arraysets['writtenaset'][key]
+    assert out.dtype == val.dtype
+    assert out.shape == val.shape
+    assert np.allclose(out, val)

--- a/tests/property_based/test_pbt_arrayset.py
+++ b/tests/property_based/test_pbt_arrayset.py
@@ -22,6 +22,7 @@ valid_arrays_fixed = npst.arrays(np.float64,
 
 
 @given(key=st_valid_keys, val=valid_arrays_fixed)
+@settings(max_examples=500)
 def test_arrayset_fixed_key_values(key, val, w_checkout):
     w_checkout.arraysets['writtenaset'][key] = val
     out = w_checkout.arraysets['writtenaset'][key]

--- a/tests/property_based/test_pbt_metadata.py
+++ b/tests/property_based/test_pbt_metadata.py
@@ -2,19 +2,19 @@ import pytest
 
 import string
 
-from hypothesis import given, settings
+from hypothesis import given, settings, seed
 import hypothesis.strategies as st
 
 
-st_valid_names = st.text(min_size=1, alphabet=string.ascii_letters + string.digits + '_-.', max_size=64)
-st_valid_ints = st.integers(min_value=0)
+st_valid_names = st.text(min_size=1, alphabet=string.ascii_letters + string.digits + '_-.', max_size=32)
+st_valid_ints = st.integers(min_value=0, max_value=999999)
 st_valid_keys = st.one_of(st_valid_ints, st_valid_names)
 
-st_valid_values = st.text(min_size=1, alphabet=string.printable + string.whitespace)
+st_valid_values = st.text(min_size=1, alphabet=string.printable + string.whitespace, max_size=9_999)
 
 
-@settings(max_examples=500)
+@settings(max_examples=200, deadline=3000.0)
 @given(key=st_valid_keys, val=st_valid_values)
-def test_metadata_key_values(key, val, w_checkout):
-    w_checkout.metadata[key] = val
-    assert w_checkout.metadata[key] == val
+def test_metadata_key_values(key, val, w_metadata_co):
+    w_metadata_co.metadata[key] = val
+    assert w_metadata_co.metadata[key] == val

--- a/tests/property_based/test_pbt_metadata.py
+++ b/tests/property_based/test_pbt_metadata.py
@@ -10,7 +10,7 @@ st_valid_names = st.text(min_size=1, alphabet=string.ascii_letters + string.digi
 st_valid_ints = st.integers(min_value=0)
 st_valid_keys = st.one_of(st_valid_ints, st_valid_names)
 
-st_valid_values = st.text(min_size=1, alphabet=string.printable)
+st_valid_values = st.text(min_size=1, alphabet=string.printable + string.whitespace)
 
 
 @settings(max_examples=500)

--- a/tests/property_based/test_pbt_metadata.py
+++ b/tests/property_based/test_pbt_metadata.py
@@ -1,0 +1,20 @@
+import pytest
+
+import string
+
+from hypothesis import given, settings
+import hypothesis.strategies as st
+
+
+st_valid_names = st.text(min_size=1, alphabet=string.ascii_letters + string.digits + '_-.', max_size=64)
+st_valid_ints = st.integers(min_value=0)
+st_valid_keys = st.one_of(st_valid_ints, st_valid_names)
+
+st_valid_values = st.text(min_size=1, alphabet=string.printable)
+
+
+@settings(max_examples=500)
+@given(key=st_valid_keys, val=st_valid_values)
+def test_metadata_key_values(key, val, w_checkout):
+    w_checkout.metadata[key] = val
+    assert w_checkout.metadata[key] == val

--- a/tests/test_arrayset.py
+++ b/tests/test_arrayset.py
@@ -720,7 +720,7 @@ class TestVariableSizedArrayset(object):
         'test_shapes,max_shape',
         [[[(2, 5), (1, 10), (10, 1), (5, 2)], (10, 10)],
          [[(10,), (10,)], (10,)],
-         [[(10, 10, 10), (100, 10, 1), (10, 100, 1), (1, 100, 10), (1, 10, 100), (50, 2, 10)], (100, 100, 100)]])
+         [[(3, 3, 3), (27, 1, 1), (1, 27, 1), (1, 1, 27), (3, 9, 1), (9, 3, 1), (1, 3, 9), (1, 9, 3)], (27, 27, 27)]])
     @pytest.mark.parametrize("dtype1", [np.uint8, np.float32, np.int32])
     @pytest.mark.parametrize("dtype2", [np.uint8, np.float32, np.int32])
     @pytest.mark.parametrize('backend1', backend_params)

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ deps =
     pytest-travis-fold
     pytest-xdist
     pytest-mock
+    hypothesis[numpy]
 
 [mldeps-py36]
 deps =


### PR DESCRIPTION
## Motivation and Context
#### _Why is this change required? What problem does it solve?:_

Upon adding a small set of property based tests, it was discovered that zero valued arrays in variable shaped arraysets could potentially hash to the same value if two arrays had the same `size` and/or `itemsize` but different `shapes`


## Description
#### _Describe your changes in detail:_

```python
>>> aset = co.arraysets.init_arrayset('aset', shape=(10, 10, 10, 10), dtype=np.float32, variable_shape=True)

>>> a = np.zeros(shape=(1, 1, 5, 1), dtype=np.float32)
>>> a.shape
(1, 1, 5, 1)
>>> b = np.zeros(shape=(1, 1, 1, 5), dtype=np.float32)
>>> b.shape
(1, 1, 1, 5)

>>> aset['a'] = a
>>> aset['b'] = b

>>> aset['a'].shape
(1, 1, 5, 1)
>>> aset['b'].shape
(1, 1, 5, 1)  # THIS IS INCORRECT!
```

This happens because 

```python
>>> a = np.zeros(shape=(1, 1, 5, 1), dtype=np.float32)
>>> b = np.zeros(shape=(1, 1, 1, 5), dtype=np.float32)
>>> a.tobytes() == b.tobytes()
True

>>> a_float = np.zeros(shape=(1, 1, 5, 1), dtype=np.float32)
>>> b_int = np.zeros(shape=(1, 1, 5, 1), dtype=np.int32)
>>> a_float.tobytes() == b_int.tobytes()
True
```

To fix this we now take the hash of the array bytes, with a binary struct composed of the ints making up each dimension shape and the numeric typecode of the array's dtype. 

```python
hasher = hashlib.blake2b(data, digest_size=20)
hasher.update(struct.pack(f'<{len(data.shape)}QB', *data.shape, data.dtype.num))
full_hash = hasher.hexdigest()
```

This means that any difference in type or shape (even if bytes are technically identical) will result in storage of that new array on disk and (more importantly) storage of the digest record (with corresponding variance in result spec) in the `hashenv` db. 

In addition to including the hypothesis test which found this in the test suite, manual tests have been added which assert this result does not happen. 


**This is a BREAKING CHANGE for all future versions of hangar, data hashs will no longer be the same** However, this is OK since that was going to happen in 0.4 anyways. 


## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Documentation update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Is this PR ready for review, or a work in progress?
- [x] Ready for review
- [ ] Work in progress

## How Has This Been Tested?
Put an `x` in the boxes that apply:
- [ ] Current tests cover modifications made
- [x] New tests have been added to the test suite
- [ ] Modifications were made to existing tests to support these changes
- [ ] Tests may be needed, but they are not included when the PR was proposed
- [ ] I don't know. Help!

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.rst)** document.
- [x] I have signed (or will sign when prompted) the tensorwork CLA.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
