### PR TITLE
Namedtuple bugfix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,10 @@ Bug Fixes
   (`#125 <https://github.com/tensorwerk/hangar-py/pull/125>`__) `@rlizzo <https://github.com/rlizzo>`__
 * Fixed minor bug in types of values allowed for ``Arrayset`` names vs ``Sample`` names.
   (`#151 <https://github.com/tensorwerk/hangar-py/pull/151>`__) `@rlizzo <https://github.com/rlizzo>`__
+* Fixed issue where using checkout object to access a sample in multiple arraysets would try to create
+  a ``namedtuple`` instance with invalid field names. Now incompatible field names are automatically
+  renamed with their positional index.
+  (`#161 <https://github.com/tensorwerk/hangar-py/pull/161>`__) `@rlizzo <https://github.com/rlizzo>`__
 
 
 Breaking changes

--- a/tests/test_checkout_arrayset_access.py
+++ b/tests/test_checkout_arrayset_access.py
@@ -485,7 +485,7 @@ def test_writer_co_read_slice_select_aset_multiple_samples(written_repo, array5b
     assert np.allclose(o2.newaset, array10 + 1)
     wco.close()
 
-
+@pytest.mark.filterwarnings("ignore:Arrayset names contains characters")
 @pytest.mark.parametrize('invalid_name', ['foo.bar', '_helloworld', 'fail-again', '.lol'])
 def test_writer_co_read_two_asets_one_invalid_fieldname_is_renamed(written_repo, array5by7, invalid_name):
     wco = written_repo.checkout(write=True)
@@ -520,7 +520,7 @@ def test_writer_co_read_two_asets_one_invalid_fieldname_is_renamed(written_repo,
 
     wco.close()
 
-
+@pytest.mark.filterwarnings("ignore:Arrayset names contains characters")
 @pytest.mark.parametrize('invalid_name1', ['foo.bar', '_helloworld', 'fail-again', '.lol'])
 @pytest.mark.parametrize('invalid_name2', ['foo.bar2', '_helloworld2', 'fail-again2', '.lol2'])
 def test_writer_co_read_two_asets_two_invalid_fieldname_both_renamed(repo, array5by7, invalid_name1, invalid_name2):
@@ -557,7 +557,7 @@ def test_writer_co_read_two_asets_two_invalid_fieldname_both_renamed(repo, array
 
     wco.close()
 
-
+@pytest.mark.filterwarnings("ignore:Arrayset names contains characters")
 @pytest.mark.parametrize('invalid_name1', ['foo.bar', '_helloworld', 'fail-again', '.lol'])
 @pytest.mark.parametrize('invalid_name2', ['foo.bar2', '_helloworld2', 'fail-again2', '.lol2'])
 def test_writer_co_read_all_asets_all_invalid_fieldname_both_renamed(repo, array5by7, invalid_name1, invalid_name2):
@@ -580,16 +580,28 @@ def test_writer_co_read_all_asets_all_invalid_fieldname_both_renamed(repo, array
     assert '_0' in out1._fields
     assert '_1' in out1._fields
     assert len(out1._fields) == 2
-    assert np.allclose(out1._0, array5by7) or np.allclose(out1._1, array5by7)
-    assert np.allclose(out1._0, array10) or np.allclose(out1._1, array10)
+    try:
+        assert np.allclose(out1._0, array5by7)
+    except ValueError:
+        assert np.allclose(out1._1, array5by7)
+    try:
+        assert np.allclose(out1._0, array10)
+    except ValueError:
+        assert np.allclose(out1._1, array10)
 
     out3 = wco[..., (0, 1, 2)]
     for idx, nt in enumerate(out3):
         assert '_0' in nt._fields
         assert '_1' in nt._fields
         assert len(nt._fields) == 2
-        assert np.allclose(nt._0, array5by7 + idx) or np.allclose(nt._1, array5by7 + idx)
-        assert np.allclose(nt._0, array10 + idx) or np.allclose(nt._1, array10 + idx)
+        try:
+            assert np.allclose(nt._0, array5by7 + idx)
+        except ValueError:
+            assert np.allclose(nt._1, array5by7 + idx)
+        try:
+            assert np.allclose(nt._0, array10 + idx)
+        except ValueError:
+            assert np.allclose(nt._1, array10 + idx)
     wco.close()
 
 
@@ -907,7 +919,7 @@ def test_reader_co_read_slice_select_aset_multiple_samples(written_repo, array5b
     assert np.allclose(o2.newaset, array10 + 1)
     rco.close()
 
-
+@pytest.mark.filterwarnings("ignore:Arrayset names contains characters")
 @pytest.mark.parametrize('invalid_name', ['foo.bar', '_helloworld', 'fail-again', '.lol'])
 def test_reader_co_read_two_asets_one_invalid_fieldname_is_renamed(written_repo, array5by7, invalid_name):
     wco = written_repo.checkout(write=True)
@@ -945,7 +957,7 @@ def test_reader_co_read_two_asets_one_invalid_fieldname_is_renamed(written_repo,
 
     rco.close()
 
-
+@pytest.mark.filterwarnings("ignore:Arrayset names contains characters")
 @pytest.mark.parametrize('invalid_name1', ['foo.bar', '_helloworld', 'fail-again', '.lol'])
 @pytest.mark.parametrize('invalid_name2', ['foo.bar2', '_helloworld2', 'fail-again2', '.lol2'])
 def test_reader_co_read_two_asets_two_invalid_fieldname_both_renamed(repo, array5by7, invalid_name1, invalid_name2):
@@ -985,6 +997,7 @@ def test_reader_co_read_two_asets_two_invalid_fieldname_both_renamed(repo, array
     rco.close()
 
 
+@pytest.mark.filterwarnings("ignore:Arrayset names contains characters")
 @pytest.mark.parametrize('invalid_name1', ['foo.bar', '_helloworld', 'fail-again', '.lol'])
 @pytest.mark.parametrize('invalid_name2', ['foo.bar2', '_helloworld2', 'fail-again2', '.lol2'])
 def test_reader_co_read_all_asets_all_invalid_fieldname_both_renamed(repo, array5by7, invalid_name1, invalid_name2):
@@ -1010,14 +1023,26 @@ def test_reader_co_read_all_asets_all_invalid_fieldname_both_renamed(repo, array
     assert '_0' in out1._fields
     assert '_1' in out1._fields
     assert len(out1._fields) == 2
-    assert np.allclose(out1._0, array5by7) or np.allclose(out1._1, array5by7)
-    assert np.allclose(out1._0, array10) or np.allclose(out1._1, array10)
+    try:
+        assert np.allclose(out1._0, array5by7)
+    except ValueError:
+        assert np.allclose(out1._1, array5by7)
+    try:
+        assert np.allclose(out1._0, array10)
+    except ValueError:
+        assert np.allclose(out1._1, array10)
 
     out3 = rco[..., (0, 1, 2)]
     for idx, nt in enumerate(out3):
         assert '_0' in nt._fields
         assert '_1' in nt._fields
         assert len(nt._fields) == 2
-        assert np.allclose(nt._0, array5by7 + idx) or np.allclose(nt._1, array5by7 + idx)
-        assert np.allclose(nt._0, array10 + idx) or np.allclose(nt._1, array10 + idx)
+        try:
+            assert np.allclose(nt._0, array5by7 + idx)
+        except ValueError:
+            assert np.allclose(nt._1, array5by7 + idx)
+        try:
+            assert np.allclose(nt._0, array10 + idx)
+        except ValueError:
+            assert np.allclose(nt._1, array10 + idx)
     rco.close()


### PR DESCRIPTION
## Motivation and Context
#### _Why is this change required? What problem does it solve?:_

Fix incompatibility between set of possible names an `Arrayset` can take vs those valid `namedtuple` field names. 

#### _If it fixes an open issue, please link to the issue here:_

- closes #158 

## Description
#### _Describe your changes in detail:_

- Use built in `namedtuple` method to rename invalid fields with a positional index. 
- Fully documented behavior and implications; highlighting remaining limitations which remain even with this fix. 
- full test coverage?

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Documentation update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Is this PR ready for review, or a work in progress?
- [x] Ready for review
- [ ] Work in progress

## How Has This Been Tested?
Put an `x` in the boxes that apply:
- [ ] Current tests cover modifications made
- [x] New tests have been added to the test suite
- [ ] Modifications were made to existing tests to support these changes
- [ ] Tests may be needed, but they are not included when the PR was proposed
- [ ] I don't know. Help!

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.rst)** document.
- [x] I have signed (or will sign when prompted) the tensorwork CLA.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
