### PR TITLE
Bugfix - Write-Enabled checkout with commit argument raises exception

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -52,6 +52,8 @@ Bug Fixes
   a ``namedtuple`` instance with invalid field names. Now incompatible field names are automatically
   renamed with their positional index.
   (`#161 <https://github.com/tensorwerk/hangar-py/pull/161>`__) `@rlizzo <https://github.com/rlizzo>`__
+* Explicitly raise error if ``commit`` argument is set while checking out a repository with ``write=True``.
+  (`#166 <https://github.com/tensorwerk/hangar-py/pull/166>`__) `@rlizzo <https://github.com/rlizzo>`__
 
 
 Breaking changes

--- a/src/hangar/repository.py
+++ b/src/hangar/repository.py
@@ -208,6 +208,9 @@ class Repository(object):
         ------
         ValueError
             If the value of `write` argument is not boolean
+        ValueError
+            If ``commit`` argument is set to any value when ``write=True``.
+            Only ``branch`` argument is allowed.
 
         Returns
         -------
@@ -218,6 +221,10 @@ class Repository(object):
         self.__verify_repo_initialized()
         try:
             if write is True:
+                if commit != '':
+                    raise ValueError(
+                        f'Only `branch` argument can be set if `write=True`. '
+                        f'Setting `commit={commit}` not allowed.')
                 if branch == '':
                     branch = heads.get_staging_branch_head(self._env.branchenv)
                 co = WriterCheckout(

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -6,6 +6,16 @@ from conftest import fixed_shape_backend_params
 
 class TestCheckout(object):
 
+    def test_write_checkout_specifying_commit_not_allowed_if_commit_exists(self, written_repo):
+        cmt_digest = written_repo.log(return_contents=True)['head']
+        with pytest.raises(ValueError):
+            written_repo.checkout(write=True, commit=cmt_digest)
+
+    def test_write_checkout_specifying_commit_not_allowed_if_commit_does_not_exists(self, written_repo):
+        cmt_digest = 'notrealcommit'
+        with pytest.raises(ValueError):
+            written_repo.checkout(write=True, commit=cmt_digest)
+
     def test_two_write_checkouts(self, repo):
         w1_checkout = repo.checkout(write=True)
         with pytest.raises(PermissionError):


### PR DESCRIPTION
## Motivation and Context
#### _Why is this change required? What problem does it solve?:_

explicitly raise error if `commit` arg is set while checking out a repository with `write=True`

#### _If it fixes an open issue, please link to the issue here:_

- closes #164 

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Documentation update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Is this PR ready for review, or a work in progress?
- [x] Ready for review
- [ ] Work in progress

## How Has This Been Tested?
Put an `x` in the boxes that apply:
- [ ] Current tests cover modifications made
- [x] New tests have been added to the test suite
- [ ] Modifications were made to existing tests to support these changes
- [ ] Tests may be needed, but they are not included when the PR was proposed
- [ ] I don't know. Help!

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.rst)** document.
- [x] I have signed (or will sign when prompted) the tensorwork CLA.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
