### PR TITLE
Convenience Methods

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,15 @@ Improvements
 New Features
 ------------
 
+* Added ``.diff()`` method to ``Repository`` class to enable diffing changes between any pair of
+  commits / branches without needing to open the diff base in a checkout.
+  (`#183 <https://github.com/tensorwerk/hangar-py/pull/183>`__) `@rlizzo <https://github.com/rlizzo>`__
+* New CLI command ``hangar diff`` which reports a summary view of changes made between any pair of
+  commits / branches.
+  (`#183 <https://github.com/tensorwerk/hangar-py/pull/183>`__) `@rlizzo <https://github.com/rlizzo>`__
+* Added ``.log()`` method to ``Checkout`` objects so graphical commit graph or machine readable
+  commit details / DAG can be queried when operating on a particular commit.
+  (`#183 <https://github.com/tensorwerk/hangar-py/pull/183>`__) `@rlizzo <https://github.com/rlizzo>`__
 * "string" type columns now supported alongside "ndarray" column type.
   (`#180 <https://github.com/tensorwerk/hangar-py/pull/180>`__) `@rlizzo <https://github.com/rlizzo>`__
 * New "column" API, which replaces "arrayset" name.
@@ -43,6 +52,23 @@ New Features
   (`#174 <https://github.com/tensorwerk/hangar-py/pull/174>`__) `@rlizzo <https://github.com/rlizzo>`__
 * Added method to traverse the entire repository history and cryptographically verify integrity.
   (`#173 <https://github.com/tensorwerk/hangar-py/pull/173>`__) `@rlizzo <https://github.com/rlizzo>`__
+
+
+Changes
+-------
+
+* Argument syntax of ``__getitem__()`` and ``get()`` methods of ``ReaderCheckout`` and
+  ``WriterCheckout`` classes. The new format supports handeling arbitrary arguments specific
+  to retrieval of data from any column type.
+  (`#183 <https://github.com/tensorwerk/hangar-py/pull/183>`__) `@rlizzo <https://github.com/rlizzo>`__
+
+
+Removed
+-------
+
+* ``__setitem__()`` method in ``WriterCheckout`` objects.  Writing data to columns via a checkout object
+  is no longer supported.
+  (`#183 <https://github.com/tensorwerk/hangar-py/pull/183>`__) `@rlizzo <https://github.com/rlizzo>`__
 
 
 Bug Fixes

--- a/docs/Tutorial-001.ipynb
+++ b/docs/Tutorial-001.ipynb
@@ -694,10 +694,6 @@
       "--------------------------------\n",
       "Finished context manager form in: 11.608536720275879 seconds\n",
       "Hard reset requested with writer_lock: ad4a2ef9-8494-49f8-84ef-40c3990b1e9b\n",
-      "\n",
-      "Beginning context manager form with checkout access\n",
-      "--------------------------------\n",
-      "Finished context manager with checkout form in: 13.474638223648071 seconds\n"
      ]
     }
    ],
@@ -742,20 +738,6 @@
     "\n",
     "co.reset_staging_area()\n",
     "co.close()\n",
-    "\n",
-    "# -------------- Context Manager With Checkout Access -------------\n",
-    "\n",
-    "co = repo.checkout(write=True)\n",
-    "co.add_ndarray_column(name='train_images', prototype=sample_trimg)\n",
-    "co.add_ndarray_column(name='train_labels', prototype=sample_trlabel)\n",
-    "\n",
-    "print(f'\\nBeginning context manager form with checkout access')\n",
-    "print('--------------------------------')\n",
-    "start_time = time.time()\n",
-    "\n",
-    "with co:\n",
-    "    for idx, img in enumerate(trimgs):\n",
-    "        co[['train_images', 'train_labels'], idx] = [img, np.array([trlabels[idx]])]\n",
     "\n",
     "print(f'Finished context manager with checkout form in: {time.time() - start_time} seconds')"
    ]

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -26,6 +26,7 @@ Checkout
 
 .. autoclass:: hangar.checkout.WriterCheckout()
    :members:
+   :inherited-members:
    :special-members: __getitem__, __setitem__, __len__, __contains__, __iter__
    :exclude-members: __init__
 
@@ -86,6 +87,7 @@ Checkout
 
 .. autoclass:: hangar.checkout.ReaderCheckout()
    :members:
+   :inherited-members:
    :special-members: __getitem__, __len__, __contains__, __iter__
    :exclude-members: __init__
 

--- a/src/hangar/checkout.py
+++ b/src/hangar/checkout.py
@@ -590,17 +590,17 @@ class WriterCheckout(GetMixin, CheckoutDictIteration):
 
             >>> dset = repo.checkout(branch='master', write=True)
             >>>
-            >>> # Add single sample to single column
+            # Add single sample to single column
             >>> dset['foo', 1] = np.array([1])
             >>> dset['foo', 1]
             array([1])
             >>>
-            >>> # Add multiple samples to single column
+            # Add multiple samples to single column
             >>> dset['foo', [1, 2, 3]] = [np.array([1]), np.array([2]), np.array([3])]
             >>> dset['foo', [1, 2, 3]]
             [array([1]), array([2]), array([3])]
             >>>
-            >>> # Add single sample to multiple columns
+            # Add single sample to multiple columns
             >>> dset[['foo', 'bar'], 1] = [np.array([1]), np.array([11])]
             >>> dset[:, 1]
             ArraysetData(foo=array([1]), bar=array([11]))

--- a/src/hangar/cli/cli.py
+++ b/src/hangar/cli/cli.py
@@ -791,7 +791,8 @@ def view_data(ctx, repo: Repository, column, sample, startpoint, format_, plugin
 @click.option('-s', is_flag=True, help='display the stage record db')
 @click.option('-z', is_flag=True, help='display the staged hash record db')
 @click.option('--limit', default=30, help='limit the amount of records displayed before truncation')
-def lmdb_record_details(a, b, r, d, m, s, z, limit):  # pragma: no cover
+@pass_repo
+def lmdb_record_details(repo: Repository, a, b, r, d, m, s, z, limit):
     """DEVELOPER TOOL ONLY
 
     display key/value pairs making up the dbs
@@ -800,27 +801,29 @@ def lmdb_record_details(a, b, r, d, m, s, z, limit):  # pragma: no cover
     from hangar.records.summarize import details
     from hangar import constants as c
 
-    P = os.getcwd()
-    if os.path.isdir(os.path.join(P, c.DIR_HANGAR_SERVER)):
-        repo_path = os.path.join(P, c.DIR_HANGAR_SERVER)
-    elif os.path.isdir(os.path.join(P, c.DIR_HANGAR)):
-        repo_path = os.path.join(P, c.DIR_HANGAR)
+    if repo._repo_path.is_dir():
+        repo_path = repo._repo_path
+    elif repo._repo_path.parent.joinpath(c.DIR_HANGAR_SERVER).is_dir():
+        repo_path = repo._repo_path.parent.joinpath(c.DIR_HANGAR_SERVER)
     else:
-        click.echo(f'NO HANGAR INSTALLATION AT PATH: {P}')
+        click.echo(f'NO HANGAR INSTALLATION AT PATH: {repo._repo_path.parent}')
         return
 
     envs = Environments(pth=repo_path)
-    if a:
-        b, r, d, m, s, z = True, True, True, True, True, True
-    if b:
-        click.echo(details(envs.branchenv, line_limit=limit).getvalue())
-    if r:
-        click.echo(details(envs.refenv, line_limit=limit).getvalue())
-    if d:
-        click.echo(details(envs.hashenv, line_limit=limit).getvalue())
-    if m:
-        click.echo(details(envs.labelenv, line_limit=limit).getvalue())
-    if s:
-        click.echo(details(envs.stageenv, line_limit=limit).getvalue())
-    if z:
-        click.echo(details(envs.stagehashenv, line_limit=limit).getvalue())
+    try:
+        if a:
+            b, r, d, m, s, z = True, True, True, True, True, True
+        if b:
+            click.echo(details(envs.branchenv, line_limit=limit).getvalue())
+        if r:
+            click.echo(details(envs.refenv, line_limit=limit).getvalue())
+        if d:
+            click.echo(details(envs.hashenv, line_limit=limit).getvalue())
+        if m:
+            click.echo(details(envs.labelenv, line_limit=limit).getvalue())
+        if s:
+            click.echo(details(envs.stageenv, line_limit=limit).getvalue())
+        if z:
+            click.echo(details(envs.stagehashenv, line_limit=limit).getvalue())
+    finally:
+        envs._close_environments()

--- a/src/hangar/columns/__init__.py
+++ b/src/hangar/columns/__init__.py
@@ -1,5 +1,5 @@
 from .column import Columns, ModifierTypes
-from .common import AsetTxn
+from .common import ColumnTxn
 from .constructors import (
     generate_flat_column,
     generate_nested_column,
@@ -15,5 +15,5 @@ __all__ = (
     'generate_flat_column',
     'generate_nested_column',
     'column_type_object_from_schema',
-    'AsetTxn',
+    'ColumnTxn',
 )

--- a/src/hangar/columns/column.py
+++ b/src/hangar/columns/column.py
@@ -6,7 +6,7 @@ from typing import Iterable, List, Mapping, Optional, Tuple, Union, Dict
 
 import lmdb
 
-from .common import AsetTxn
+from .common import ColumnTxn
 from .constructors import (
     generate_flat_column, generate_nested_column, column_type_object_from_schema
 )
@@ -42,7 +42,7 @@ class Columns:
                  hashenv: Optional[lmdb.Environment] = None,
                  dataenv: Optional[lmdb.Environment] = None,
                  stagehashenv: Optional[lmdb.Environment] = None,
-                 txnctx: Optional[AsetTxn] = None):
+                 txnctx: Optional[ColumnTxn] = None):
         """Developer documentation for init method.
 
         .. warning::
@@ -68,7 +68,7 @@ class Columns:
             cmtrefenv for read-only checkouts.
         stagehashenv : Optional[lmdb.Environment]
             environment handle for newly added staged data hash records.
-        txnctx: Optional[AsetTxn]
+        txnctx: Optional[ColumnTxn]
             class implementing context managers to handle lmdb transactions
         """
         self._stack: Optional[ExitStack] = None
@@ -415,7 +415,7 @@ class Columns:
             live column data accessors in `write` mode.
         """
         columns = {}
-        txnctx = AsetTxn(stageenv, hashenv, stagehashenv)
+        txnctx = ColumnTxn(stageenv, hashenv, stagehashenv)
         query = RecordQuery(stageenv)
         stagedSchemaSpecs = query.schema_specs()
 
@@ -474,7 +474,7 @@ class Columns:
             contains live column data accessors in `read-only` mode.
         """
         columns = {}
-        txnctx = AsetTxn(cmtrefenv, hashenv, None)
+        txnctx = ColumnTxn(cmtrefenv, hashenv, None)
         query = RecordQuery(cmtrefenv)
         cmtSchemaSpecs = query.schema_specs()
 

--- a/src/hangar/columns/common.py
+++ b/src/hangar/columns/common.py
@@ -6,7 +6,7 @@ import lmdb
 from ..txnctx import TxnRegister
 
 
-class AsetTxn(object):
+class ColumnTxn(object):
     """Provides context manager ready methods to handle lmdb transactions.
 
     In order to prevent passing around lmdb.Environment objects, we instantiate

--- a/src/hangar/columns/constructors.py
+++ b/src/hangar/columns/constructors.py
@@ -55,7 +55,7 @@ def _flat_load_sample_keys_and_specs(column_name, txnctx):
     ----------
     column_name: str
         name of the column to load.
-    txnctx: AsetTxn
+    txnctx: ColumnTxn
         transaction context object used to access commit ref info on disk
 
     Returns
@@ -84,7 +84,7 @@ def generate_flat_column(txnctx, column_name, path, schema, mode):
 
     Parameters
     ----------
-    txnctx : AsetTxn
+    txnctx : ColumnTxn
         transaction context object used to access commit ref info on disk
     column_name : str
         name of the column that the reader constructors are being
@@ -141,7 +141,7 @@ def _nested_load_sample_keys_and_specs(column_name, txnctx):
     ----------
     column_name : str
         name of the column to load.
-    txnctx : AsetTxn
+    txnctx : ColumnTxn
         transaction context object used to access commit ref info on disk
 
     Returns
@@ -171,7 +171,7 @@ def generate_nested_column(txnctx, column_name, path, schema, mode):
 
     Parameters
     ----------
-    txnctx : AsetTxn
+    txnctx : ColumnTxn
         transaction context object used to access commit ref info on disk
     column_name : str
         name of the column that the reader constructors are being

--- a/src/hangar/constants.py
+++ b/src/hangar/constants.py
@@ -1,3 +1,5 @@
+from .utils import is_64bits, parse_bytes
+
 # parsing constants
 
 SEP_KEY = ':'
@@ -39,8 +41,10 @@ CONFIG_SERVER_NAME = 'config_server.ini'
 
 # LMDB database names and settings.
 
+
 LMDB_SETTINGS = {
-    'map_size': 2_000_000_000,
+    # lmdb cannot open map larger than 2GB on 32 bit machines.
+    'map_size': 50_000_000_000,
     'meminit': False,
     'subdir': False,
     'lock': False,

--- a/src/hangar/context.py
+++ b/src/hangar/context.py
@@ -38,7 +38,7 @@ from .records.vcompat import (
     set_repository_software_version,
     startup_check_repo_version,
 )
-from .utils import readme_contents
+from .utils import readme_contents, is_64bits
 
 
 class Environments(object):
@@ -93,6 +93,9 @@ class Environments(object):
             msg = f'No repository exists at {self.repo_path}, please use `repo.init()` method'
             warnings.warn(msg, UserWarning)
             return False
+
+        if not is_64bits():
+            raise OSError(f'Hangar cannot run on 32 bit machines')
 
         repo_ver = startup_check_repo_version(self.repo_path)
         curr_ver = repo_version_raw_spec_from_raw_string(v_str=__version__)

--- a/src/hangar/diff.py
+++ b/src/hangar/diff.py
@@ -189,9 +189,12 @@ def _raw_from_db_change(changes: Set[Tuple[bytes, bytes]]) -> Changes:
         elif k[:2] == b'l:':
             metadataKeys.append(k)
             continue
-        else:  # k[:2] == b's:'
+        elif k[:2] == b's:':
             schemaKeyVals.append((k, v))
             continue
+        else:
+            raise RuntimeError(f'Unknown record type prefix encountered: '
+                               f'{k[:2]}. full record => k: {k} & v: {v}')
 
     columndata = map(dynamic_layout_data_record_from_db_key, columnKeys)
     metadata = map(metadata_record_raw_key_from_db_key, metadataKeys)

--- a/src/hangar/mixins/datasetget.py
+++ b/src/hangar/mixins/datasetget.py
@@ -21,32 +21,26 @@ class GetMixin:
         view of samples across columns.
 
             >>> dset = repo.checkout(branch='master')
-
-        Get an column contained in the checkout.
-
+            >>>
+            # Get an column contained in the checkout.
             >>> dset['foo']
             ColumnDataReader
-
-        Get a specific sample from ``'foo'`` (returns a single array)
-
+            >>>
+            # Get a specific sample from ``'foo'`` (returns a single array)
             >>> dset['foo', '1']
             np.array([1])
-
-        Get multiple samples from ``'foo'`` (returns a list of arrays, in order
-        of input keys)
-
+            >>>
+            # Get multiple samples from ``'foo'`` (returns a list of arrays, in order
+            # of input keys)
             >>> dset[['foo', '1'], ['foo', '2'],  ['foo', '324']]
             [np.array([1]), np.ndarray([2]), np.ndarray([324])]
-
-        Get sample from multiple columns, column/data returned is ordered
-        in same manner as input of func.
-
+            >>>
+            # Get sample from multiple columns, column/data returned is ordered
+            # in same manner as input of func.
             >>> dset[['foo', '1'], ['bar', '1'],  ['baz', '1']]
             [np.array([1]), np.ndarray([1, 1]), np.ndarray([1, 1, 1])]
-
-        Get multiple samples from multiple columns(returns list of namedtuple
-        of array sorted in input key order, field names = column names)
-
+            >>>
+            # Get multiple samples from multiple columns\
             >>> keys = [(col, str(samp)) for samp in range(2) for col in ['foo', 'bar']]
             >>> keys
             [('foo', '0'), ('bar', '0'), ('foo', '1'), ('bar', '1')]
@@ -60,11 +54,11 @@ class GetMixin:
             >>> dset['nested_col', 'sample_1', 'subsample_0']
             np.array([1, 0])
             >>>
-            >>> # a sample accessor object can be retrieved at will...
+            # a sample accessor object can be retrieved at will...
             >>> dset['nested_col', 'sample_1']
             <class 'FlatSubsampleReader'>(column_name='nested_col', sample_name='sample_1')
             >>>
-            >>> # to get all subsamples in a nested sample use the Ellipsis operator
+            # to get all subsamples in a nested sample use the Ellipsis operator
             >>> dset['nested_col', 'sample_1', ...]
             {'subsample_0': np.array([1, 0]),
              'subsample_1': np.array([1, 1]),
@@ -84,249 +78,135 @@ class GetMixin:
             [np.array([0]),
              <class 'FlatSubsampleReader'>(column_name='nested_col', sample_name='sample_1')]
 
+        If a column or data key does not exist, then this method will raise a KeyError.
+        As an alternative, missing keys can be gracefully handeled by calling :meth:`get()`
+        instead. This method does not (by default) raise an error if a key is missing.
+        Instead, a (configurable) default value is simply inserted in it's place.
 
-        TODO: REMOVE/Rework following documentation
-        #
-        # Get samples from all columns (shortcut syntax)
-        #
-        #     >>> out = dset[:, ('1', '2')]
-        #     >>> out
-        #     [ColumnData(foo=array([1]), bar=array([11]), baz=array([111])),
-        #      ColumnData(foo=array([2]), bar=array([22]), baz=array([222]))]
-        #     >>> out = dset[..., ('1', '2')]
-        #     >>> out
-        #     [ColumnData(foo=array([1]), bar=array([11]), baz=array([111])),
-        #      ColumnData(foo=array([2]), bar=array([22]), baz=array([222]))]
-        #     >>>
-        #     >>> out = dset[:, '1']
-        #     >>> out
-        #     ColumnData(foo=array([1]), bar=array([11]), baz=array([111]))
-        #     >>> out = dset[..., '1']
-        #     >>> out
-        #     ColumnData(foo=array([1]), bar=array([11]), baz=array([111]))
-        #
-        #
-        # .. warning::
-        #
-        #     It is possible for an :class:`~.columns.column.Columns` name to be an
-        #     invalid field name for a ``namedtuple`` object. The python docs state:
-        #
-        #         Any valid Python identifier may be used for a fieldname except for
-        #         names starting with an underscore. Valid identifiers consist of
-        #         letters, digits, and underscores but do not start with a digit or
-        #         underscore and cannot be a keyword such as class, for, return,
-        #         global, pass, or raise.
-        #
-        #     In addition, names must be unique, and cannot containing a period
-        #     (``.``) or dash (``-``) character. If a namedtuple would normally be
-        #     returned during some operation, and the field name is invalid, a
-        #     :class:`UserWarning` will be emitted indicating that any suspect fields
-        #     names will be replaced with the positional index as is customary in the
-        #     python standard library. The ``namedtuple`` docs explain this by
-        #     saying:
-        #
-        #         If rename is true, invalid fieldnames are automatically replaced with
-        #         positional names. For example, ['abc', 'def', 'ghi', 'abc'] is
-        #         converted to ['abc', '_1', 'ghi', '_3'], eliminating the keyword def
-        #         and the duplicate fieldname abc.
-        #
-        #     The next section demonstrates the implications and workarounds for this
-        #     issue
-        #
-        # As an example, if we attempted to retrieve samples from columns with
-        # the names: ``['raw', 'data.jpeg', '_garba-ge', 'try_2']``, two of the
-        # four would be renamed:
-        #
-        #     >>> out = dset[('raw', 'data.jpeg', '_garba-ge', 'try_2'), '1']
-        #     >>> print(out)
-        #     ColumnData(raw=array([0]), _1=array([1]), _2=array([2]), try_2==array([3]))
-        #     >>> print(out._fields)
-        #     ('raw', '_1', '_2', 'try_2')
-        #     >>> out.raw
-        #     array([0])
-        #     >>> out._2
-        #     array([4])
-        #
-        # In cases where the input columns are explicitly specified, then, then
-        # it is guaranteed that the order of fields in the resulting tuple is
-        # exactly what was requested in the input
-        #
-        #     >>> out = dset[('raw', 'data.jpeg', '_garba-ge', 'try_2'), '1']
-        #     >>> out._fields
-        #     ('raw', '_1', '_2', 'try_2')
-        #     >>> reorder = dset[('data.jpeg', 'try_2', 'raw', '_garba-ge'), '1']
-        #     >>> reorder._fields
-        #     ('_0', 'try_2', 'raw', '_3')
-        #
-        # However, if an ``Ellipsis`` (``...``) or ``slice`` (``:``) syntax is
-        # used to select columns, *the order in which columns are placed into
-        # the namedtuple IS NOT predictable.* Should any column have an invalid
-        # field name, it will be renamed according to it's positional index, but
-        # will not contain any identifying mark. At the moment, there is no
-        # direct way to infer the column name from this structure alone. This
-        # limitation will be addressed in a future release.
-        #
-        # Do NOT rely on any observed patterns. For this corner-case, **the ONLY
-        # guarantee we provide is that structures returned from multi-sample
-        # queries have the same order in every ``ColumnData`` tuple returned in
-        # that queries result list!** Should another query be made with
-        # unspecified ordering, you should assume that the indices of the
-        # columns in the namedtuple would have changed from the previous
-        # result!!
-        #
-        #     >>> print(dset.columns.keys())
-        #     ('raw', 'data.jpeg', '_garba-ge', 'try_2']
-        #     >>> out = dset[:, '1']
-        #     >>> out._fields
-        #     ('_0', 'raw', '_2', 'try_2')
-        #     >>>
-        #     >>> # ordering in a single query is preserved
-        #     >>> multi_sample = dset[..., ('1', '2')]
-        #     >>> multi_sample[0]._fields
-        #     ('try_2', '_1', 'raw', '_3')
-        #     >>> multi_sample[1]._fields
-        #     ('try_2', '_1', 'raw', '_3')
-        #     >>>
-        #     >>> # but it may change upon a later query
-        #     >>> multi_sample2 = dset[..., ('1', '2')]
-        #     >>> multi_sample2[0]._fields
-        #     ('_0', '_1', 'raw', 'try_2')
-        #     >>> multi_sample2[1]._fields
-        #     ('_0', '_1', 'raw', 'try_2')
+            >>> dset['foo', 'DOES_NOT_EXIST']
+            -------------------------------------------------------------------
+            KeyError                           Traceback (most recent call last)
+            <ipython-input-40-731e6ea62fb8> in <module>
+            ----> 1 res = co['foo', 'DOES_NOT_EXIST']
+            KeyError: 'DOES_NOT_EXIST'
 
         Parameters
         ----------
         index
-            Please see detailed explanation above for full options. Hard coded
-            options are the order to specification.
+            column name, sample key(s) or sequence of list/tuple of column name,
+            sample keys(s) which should be retrieved in the operation.
 
-            # TODO: Rewrite documentation
-            #
-            # The first element (or collection) specified must be ``str`` type and
-            # correspond to an column name(s). Alternatively the Ellipsis operator
-            # (``...``) or unbounded slice operator (``:`` <==> ``slice(None)``) can
-            # be used to indicate "select all" behavior.
-            #
-            # If a second element (or collection) is present, the keys correspond to
-            # sample names present within (all) the specified columns. If a key is
-            # not present in even on column, the entire ``get`` operation will
-            # abort with ``KeyError``. If desired, the same selection syntax can be
-            # used with the :meth:`~hangar.checkout.ReaderCheckout.get` method, which
-            # will not Error in these situations, but simply return ``None`` values
-            # in the appropriate position for keys which do not exist.
+            Please see detailed explanation above for full explanation of accepted
+            argument format / result types.
 
         Returns
         -------
         :class:`~.columns.column.Columns`
             single column parameter, no samples specified
-
         Any
             Single column specified, single sample key specified
-
         List[Any]
             arbitrary columns, multiple samples array data for each sample is
             returned in same order sample keys are received.
-
-
-        .. seealso:
-
-            :meth:`~hangar.checkout.ReaderCheckout.get`
         """
-        with ExitStack() as stack:
-            if not self._is_conman:
-                stack.enter_context(self)
-
-            if isinstance(index, str):
-                return self.columns[index]
-            else:
-                return self.get_in(index, except_missing=True)
+        # not using kwargs since this could be in a tight loop.
+        # kwargs: default-None, except_missing=True
+        return self._get_in(index, None, True)
 
     def get(self, keys, default=None, except_missing=False):
         """View of sample data across columns gracefully handling missing sample keys.
 
-        Please see :meth:`__getitem__` for full description. This method is
+        Please see :meth:`__getitem__()` for full description. This method is
         identical with a single exception: if a sample key is not present in an
         column, this method will plane a null ``None`` value in it's return
         slot rather than throwing a ``KeyError`` like the dict style access
         does.
 
-        # TODO: Rewrite docstring
-        #
-        # Parameters
-        # ----------
-        # columns: Union[str, Iterable[str], Ellipses, slice(None)]
-        #
-        #     Name(s) of the columns to query. The Ellipsis operator (``...``)
-        #     or unbounded slice operator (``:`` <==> ``slice(None)``) can be
-        #     used to indicate "select all" behavior.
-        #
-        # samples: Union[str, int, Iterable[Union[str, int]]]
-        #
-        #     Names(s) of the samples to query
-        #
-        # except_missing: bool, **KWARG ONLY**
-        #
-        #     If False, will not throw exceptions on missing sample key value.
-        #     Will raise KeyError if True and missing key found.
+        Parameters
+        ----------
+        keys
+            sequence of column name (and optionally) sample key(s) or sequence of
+            list/tuple of column name, sample keys(s) which should be retrieved in
+            the operation.
+
+            Please see detailed explanation in :meth:`__getitem__()` for full
+            explanation of accepted argument format / result types.
+
+        default: Any, optional
+            default value to insert in results for the case where some column
+            name / sample key is not found, and the `except_missing` parameter
+            is set to False.
+
+        except_missing: bool, optional
+            If False, will not throw exceptions on missing sample key value.
+            Will raise KeyError if True and missing key found.
 
         Returns
         -------
         :class:`~.columns.column.Columns`
             single column parameter, no samples specified
-
         Any
             Single column specified, single sample key specified
+        List[Any]
+            arbitrary columns, multiple samples array data for each sample is
+            returned in same order sample keys are received.
+        """
+        return self._get_in(keys, default, except_missing)
 
+    def _get_in(self, keys, default=None, except_missing=False,
+                *, _EXCEPTION_CLASSES = (KeyError, IndexError, TypeError)):
+        """Internal method to get data from columns within a nested set of dicts.
+
+        Parameters
+        ----------
+        keys
+            sequence of column name (and optionally) sample key(s) or sequence of
+            list/tuple of column name, sample keys(s) which should be retrieved in
+            the operation.
+
+            Please see detailed explanation in :meth:`__getitem__()` for full
+            explanation of accepted argument format / result types.
+
+        default: Any, optional
+            default value to insert in results for the case where some column
+            name / sample key is not found, and the `except_missing` parameter
+            is set to False.
+
+        except_missing: bool, optional
+            If False, will not throw exceptions on missing sample key value.
+            Will raise KeyError if True and missing key found.
+
+        Returns
+        -------
+        Any
+            Single column specified, single sample key specified
         List[Any]
             arbitrary columns, multiple samples array data for each sample is
             returned in same order sample keys are received.
         """
         with ExitStack() as stack:
-            if not self._is_conman:
+            if not bool(self._enter_count):
                 stack.enter_context(self)
 
             if isinstance(keys, str):
-                return self.columns[keys]
+                return self._columns[keys]
 
-            return self.get_in(keys, default, except_missing)
-
-    def get_in(self, keys, default=None, except_missing=False):
-        """Returns coll[i0][i1]...[iX] where [i0, i1, ..., iX]==keys.
-
-        If column[i0][i1]...[iX] cannot be found, returns ``default``, unless
-        ``except_missing`` is specified, then it raises KeyError or IndexError.
-
-        ``get_in`` is a generalization of ``operator.getitem`` for nested data
-        structures such as dictionaries and lists.
-
-        Parameters
-        ----------
-        keys
-        default
-        except_missing
-
-        Returns
-        -------
-
-        """
-        with ExitStack() as stack:
-            if not self._is_conman:
-                stack.enter_context(self)
-
+            _COLUMNS = self._columns
             if len(keys) >= 2 and any([isinstance(k, (list, tuple)) for k in keys]):
                 res = []
                 for key in keys:
                     try:
-                        res.append(reduce(op_getitem, key, self.columns))
-                    except (KeyError, IndexError, TypeError):
+                        tmp = reduce(op_getitem, key, _COLUMNS)
+                        res.append(tmp)
+                    except _EXCEPTION_CLASSES:
                         if except_missing:
                             raise
                         res.append(default)
                 return res
             else:
                 try:
-                    return reduce(op_getitem, keys, self.columns)
-                except (KeyError, IndexError, TypeError):
+                    return reduce(op_getitem, keys, _COLUMNS)
+                except _EXCEPTION_CLASSES:
                     if except_missing:
                         raise
                     return default

--- a/src/hangar/mixins/datasetget.py
+++ b/src/hangar/mixins/datasetget.py
@@ -1,3 +1,5 @@
+from functools import reduce
+from operator import getitem as op_getitem
 from contextlib import ExitStack
 
 from collections import namedtuple
@@ -33,127 +35,164 @@ class GetMixin:
         Get multiple samples from ``'foo'`` (returns a list of arrays, in order
         of input keys)
 
-            >>> dset['foo', ['1', '2', '324']]
+            >>> dset[['foo', '1'], ['foo', '2'],  ['foo', '324']]
             [np.array([1]), np.ndarray([2]), np.ndarray([324])]
 
-        Get sample from multiple columns (returns namedtuple of arrays, field
-        names = column names)
+        Get sample from multiple columns, column/data returned is ordered
+        in same manner as input of func.
 
-            >>> dset[('foo', 'bar', 'baz'), '1']
-            ColumnData(foo=array([1]), bar=array([11]), baz=array([111]))
+            >>> dset[['foo', '1'], ['bar', '1'],  ['baz', '1']]
+            [np.array([1]), np.ndarray([1, 1]), np.ndarray([1, 1, 1])]
 
         Get multiple samples from multiple columns(returns list of namedtuple
         of array sorted in input key order, field names = column names)
 
-            >>> dset[('foo', 'bar'), ('1', '2')]
-            [ColumnData(foo=array([1]), bar=array([11])),
-             ColumnData(foo=array([2]), bar=array([22]))]
+            >>> keys = [(col, str(samp)) for samp in range(2) for col in ['foo', 'bar']]
+            >>> keys
+            [('foo', '0'), ('bar', '0'), ('foo', '1'), ('bar', '1')]
+            >>> dset[keys]
+            [np.array([1]), np.array([1, 1]), np.array([2]), np.array([2, 2])]
 
-        Get samples from all columns (shortcut syntax)
+        Arbitrary column layouts are supported by simply adding additional members
+        to the keys for each piece of data. For example, getting data from a column
+        with a nested layout:
 
-            >>> out = dset[:, ('1', '2')]
-            >>> out
-            [ColumnData(foo=array([1]), bar=array([11]), baz=array([111])),
-             ColumnData(foo=array([2]), bar=array([22]), baz=array([222]))]
-            >>> out = dset[..., ('1', '2')]
-            >>> out
-            [ColumnData(foo=array([1]), bar=array([11]), baz=array([111])),
-             ColumnData(foo=array([2]), bar=array([22]), baz=array([222]))]
+            >>> dset['nested_col', 'sample_1', 'subsample_0']
+            np.array([1, 0])
             >>>
-            >>> out = dset[:, '1']
-            >>> out
-            ColumnData(foo=array([1]), bar=array([11]), baz=array([111]))
-            >>> out = dset[..., '1']
-            >>> out
-            ColumnData(foo=array([1]), bar=array([11]), baz=array([111]))
-
-        .. warning::
-
-            It is possible for an :class:`~.columns.column.Columns` name to be an
-            invalid field name for a ``namedtuple`` object. The python docs state:
-
-                Any valid Python identifier may be used for a fieldname except for
-                names starting with an underscore. Valid identifiers consist of
-                letters, digits, and underscores but do not start with a digit or
-                underscore and cannot be a keyword such as class, for, return,
-                global, pass, or raise.
-
-            In addition, names must be unique, and cannot containing a period
-            (``.``) or dash (``-``) character. If a namedtuple would normally be
-            returned during some operation, and the field name is invalid, a
-            :class:`UserWarning` will be emitted indicating that any suspect fields
-            names will be replaced with the positional index as is customary in the
-            python standard library. The ``namedtuple`` docs explain this by
-            saying:
-
-                If rename is true, invalid fieldnames are automatically replaced with
-                positional names. For example, ['abc', 'def', 'ghi', 'abc'] is
-                converted to ['abc', '_1', 'ghi', '_3'], eliminating the keyword def
-                and the duplicate fieldname abc.
-
-            The next section demonstrates the implications and workarounds for this
-            issue
-
-        As an example, if we attempted to retrieve samples from columns with
-        the names: ``['raw', 'data.jpeg', '_garba-ge', 'try_2']``, two of the
-        four would be renamed:
-
-            >>> out = dset[('raw', 'data.jpeg', '_garba-ge', 'try_2'), '1']
-            >>> print(out)
-            ColumnData(raw=array([0]), _1=array([1]), _2=array([2]), try_2==array([3]))
-            >>> print(out._fields)
-            ('raw', '_1', '_2', 'try_2')
-            >>> out.raw
-            array([0])
-            >>> out._2
-            array([4])
-
-        In cases where the input columns are explicitly specified, then, then
-        it is guaranteed that the order of fields in the resulting tuple is
-        exactly what was requested in the input
-
-            >>> out = dset[('raw', 'data.jpeg', '_garba-ge', 'try_2'), '1']
-            >>> out._fields
-            ('raw', '_1', '_2', 'try_2')
-            >>> reorder = dset[('data.jpeg', 'try_2', 'raw', '_garba-ge'), '1']
-            >>> reorder._fields
-            ('_0', 'try_2', 'raw', '_3')
-
-        However, if an ``Ellipsis`` (``...``) or ``slice`` (``:``) syntax is
-        used to select columns, *the order in which columns are placed into
-        the namedtuple IS NOT predictable.* Should any column have an invalid
-        field name, it will be renamed according to it's positional index, but
-        will not contain any identifying mark. At the moment, there is no
-        direct way to infer the column name from this structure alone. This
-        limitation will be addressed in a future release.
-
-        Do NOT rely on any observed patterns. For this corner-case, **the ONLY
-        guarantee we provide is that structures returned from multi-sample
-        queries have the same order in every ``ColumnData`` tuple returned in
-        that queries result list!** Should another query be made with
-        unspecified ordering, you should assume that the indices of the
-        columns in the namedtuple would have changed from the previous
-        result!!
-
-            >>> print(dset.columns.keys())
-            ('raw', 'data.jpeg', '_garba-ge', 'try_2']
-            >>> out = dset[:, '1']
-            >>> out._fields
-            ('_0', 'raw', '_2', 'try_2')
+            >>> # a sample accessor object can be retrieved at will...
+            >>> dset['nested_col', 'sample_1']
+            <class 'FlatSubsampleReader'>(column_name='nested_col', sample_name='sample_1')
             >>>
-            >>> # ordering in a single query is preserved
-            >>> multi_sample = dset[..., ('1', '2')]
-            >>> multi_sample[0]._fields
-            ('try_2', '_1', 'raw', '_3')
-            >>> multi_sample[1]._fields
-            ('try_2', '_1', 'raw', '_3')
-            >>>
-            >>> # but it may change upon a later query
-            >>> multi_sample2 = dset[..., ('1', '2')]
-            >>> multi_sample2[0]._fields
-            ('_0', '_1', 'raw', 'try_2')
-            >>> multi_sample2[1]._fields
-            ('_0', '_1', 'raw', 'try_2')
+            >>> # to get all subsamples in a nested sample use the Ellipsis operator
+            >>> dset['nested_col', 'sample_1', ...]
+            {'subsample_0': np.array([1, 0]),
+             'subsample_1': np.array([1, 1]),
+             ...
+             'subsample_n': np.array([1, 255])}
+
+        Retrieval of data from different column types can be mixed and combined
+        as desired. For example, retrieving data from both flat and nested columns
+        simultaneously:
+
+            >>> dset[('nested_col', 'sample_1', '0'), ('foo', '0')]
+            [np.array([1, 0]), np.array([0])]
+            >>> dset[('nested_col', 'sample_1', ...), ('foo', '0')]
+            [{'subsample_0': np.array([1, 0]), 'subsample_1': np.array([1, 1])},
+             np.array([0])]
+            >>> dset[('foo', '0'), ('nested_col', 'sample_1')]
+            [np.array([0]),
+             <class 'FlatSubsampleReader'>(column_name='nested_col', sample_name='sample_1')]
+
+
+        TODO: REMOVE/Rework following documentation
+        #
+        # Get samples from all columns (shortcut syntax)
+        #
+        #     >>> out = dset[:, ('1', '2')]
+        #     >>> out
+        #     [ColumnData(foo=array([1]), bar=array([11]), baz=array([111])),
+        #      ColumnData(foo=array([2]), bar=array([22]), baz=array([222]))]
+        #     >>> out = dset[..., ('1', '2')]
+        #     >>> out
+        #     [ColumnData(foo=array([1]), bar=array([11]), baz=array([111])),
+        #      ColumnData(foo=array([2]), bar=array([22]), baz=array([222]))]
+        #     >>>
+        #     >>> out = dset[:, '1']
+        #     >>> out
+        #     ColumnData(foo=array([1]), bar=array([11]), baz=array([111]))
+        #     >>> out = dset[..., '1']
+        #     >>> out
+        #     ColumnData(foo=array([1]), bar=array([11]), baz=array([111]))
+        #
+        #
+        # .. warning::
+        #
+        #     It is possible for an :class:`~.columns.column.Columns` name to be an
+        #     invalid field name for a ``namedtuple`` object. The python docs state:
+        #
+        #         Any valid Python identifier may be used for a fieldname except for
+        #         names starting with an underscore. Valid identifiers consist of
+        #         letters, digits, and underscores but do not start with a digit or
+        #         underscore and cannot be a keyword such as class, for, return,
+        #         global, pass, or raise.
+        #
+        #     In addition, names must be unique, and cannot containing a period
+        #     (``.``) or dash (``-``) character. If a namedtuple would normally be
+        #     returned during some operation, and the field name is invalid, a
+        #     :class:`UserWarning` will be emitted indicating that any suspect fields
+        #     names will be replaced with the positional index as is customary in the
+        #     python standard library. The ``namedtuple`` docs explain this by
+        #     saying:
+        #
+        #         If rename is true, invalid fieldnames are automatically replaced with
+        #         positional names. For example, ['abc', 'def', 'ghi', 'abc'] is
+        #         converted to ['abc', '_1', 'ghi', '_3'], eliminating the keyword def
+        #         and the duplicate fieldname abc.
+        #
+        #     The next section demonstrates the implications and workarounds for this
+        #     issue
+        #
+        # As an example, if we attempted to retrieve samples from columns with
+        # the names: ``['raw', 'data.jpeg', '_garba-ge', 'try_2']``, two of the
+        # four would be renamed:
+        #
+        #     >>> out = dset[('raw', 'data.jpeg', '_garba-ge', 'try_2'), '1']
+        #     >>> print(out)
+        #     ColumnData(raw=array([0]), _1=array([1]), _2=array([2]), try_2==array([3]))
+        #     >>> print(out._fields)
+        #     ('raw', '_1', '_2', 'try_2')
+        #     >>> out.raw
+        #     array([0])
+        #     >>> out._2
+        #     array([4])
+        #
+        # In cases where the input columns are explicitly specified, then, then
+        # it is guaranteed that the order of fields in the resulting tuple is
+        # exactly what was requested in the input
+        #
+        #     >>> out = dset[('raw', 'data.jpeg', '_garba-ge', 'try_2'), '1']
+        #     >>> out._fields
+        #     ('raw', '_1', '_2', 'try_2')
+        #     >>> reorder = dset[('data.jpeg', 'try_2', 'raw', '_garba-ge'), '1']
+        #     >>> reorder._fields
+        #     ('_0', 'try_2', 'raw', '_3')
+        #
+        # However, if an ``Ellipsis`` (``...``) or ``slice`` (``:``) syntax is
+        # used to select columns, *the order in which columns are placed into
+        # the namedtuple IS NOT predictable.* Should any column have an invalid
+        # field name, it will be renamed according to it's positional index, but
+        # will not contain any identifying mark. At the moment, there is no
+        # direct way to infer the column name from this structure alone. This
+        # limitation will be addressed in a future release.
+        #
+        # Do NOT rely on any observed patterns. For this corner-case, **the ONLY
+        # guarantee we provide is that structures returned from multi-sample
+        # queries have the same order in every ``ColumnData`` tuple returned in
+        # that queries result list!** Should another query be made with
+        # unspecified ordering, you should assume that the indices of the
+        # columns in the namedtuple would have changed from the previous
+        # result!!
+        #
+        #     >>> print(dset.columns.keys())
+        #     ('raw', 'data.jpeg', '_garba-ge', 'try_2']
+        #     >>> out = dset[:, '1']
+        #     >>> out._fields
+        #     ('_0', 'raw', '_2', 'try_2')
+        #     >>>
+        #     >>> # ordering in a single query is preserved
+        #     >>> multi_sample = dset[..., ('1', '2')]
+        #     >>> multi_sample[0]._fields
+        #     ('try_2', '_1', 'raw', '_3')
+        #     >>> multi_sample[1]._fields
+        #     ('try_2', '_1', 'raw', '_3')
+        #     >>>
+        #     >>> # but it may change upon a later query
+        #     >>> multi_sample2 = dset[..., ('1', '2')]
+        #     >>> multi_sample2[0]._fields
+        #     ('_0', '_1', 'raw', 'try_2')
+        #     >>> multi_sample2[1]._fields
+        #     ('_0', '_1', 'raw', 'try_2')
 
         Parameters
         ----------
@@ -161,18 +200,20 @@ class GetMixin:
             Please see detailed explanation above for full options. Hard coded
             options are the order to specification.
 
-            The first element (or collection) specified must be ``str`` type and
-            correspond to an column name(s). Alternatively the Ellipsis operator
-            (``...``) or unbounded slice operator (``:`` <==> ``slice(None)``) can
-            be used to indicate "select all" behavior.
-
-            If a second element (or collection) is present, the keys correspond to
-            sample names present within (all) the specified columns. If a key is
-            not present in even on column, the entire ``get`` operation will
-            abort with ``KeyError``. If desired, the same selection syntax can be
-            used with the :meth:`~hangar.checkout.ReaderCheckout.get` method, which
-            will not Error in these situations, but simply return ``None`` values
-            in the appropriate position for keys which do not exist.
+            # TODO: Rewrite documentation
+            #
+            # The first element (or collection) specified must be ``str`` type and
+            # correspond to an column name(s). Alternatively the Ellipsis operator
+            # (``...``) or unbounded slice operator (``:`` <==> ``slice(None)``) can
+            # be used to indicate "select all" behavior.
+            #
+            # If a second element (or collection) is present, the keys correspond to
+            # sample names present within (all) the specified columns. If a key is
+            # not present in even on column, the entire ``get`` operation will
+            # abort with ``KeyError``. If desired, the same selection syntax can be
+            # used with the :meth:`~hangar.checkout.ReaderCheckout.get` method, which
+            # will not Error in these situations, but simply return ``None`` values
+            # in the appropriate position for keys which do not exist.
 
         Returns
         -------
@@ -183,39 +224,13 @@ class GetMixin:
             Single column specified, single sample key specified
 
         List[Any]
-            Single column, multiple samples array data for each sample is
+            arbitrary columns, multiple samples array data for each sample is
             returned in same order sample keys are received.
 
-        List[NamedTuple[``*``Any]]
-            Multiple columns, multiple samples. Each column's name is used
-            as a field in the NamedTuple elements, each NamedTuple contains
-            arrays stored in each column via a common sample key. Each sample
-            key is returned values as an individual element in the
-            List. The sample order is returned in the same order it was received.
-
-        Warns
-        -----
-        UserWarning
-            Column names contains characters which are invalid as namedtuple fields.
-
-        Notes
-        -----
-
-        *  All specified columns must exist
-
-        *  All specified sample `keys` must exist in all specified columns,
-           otherwise standard exception thrown
-
-        *  Slice syntax cannot be used in sample `keys` field
-
-        *  Slice syntax for column field cannot specify `start`, `stop`, or
-           `step` fields, it is solely a shortcut syntax for 'get all columns' in
-           the ``:`` or ``slice(None)`` form
 
         .. seealso:
 
             :meth:`~hangar.checkout.ReaderCheckout.get`
-
         """
         with ExitStack() as stack:
             if not self._is_conman:
@@ -223,14 +238,10 @@ class GetMixin:
 
             if isinstance(index, str):
                 return self.columns[index]
-            elif not isinstance(index, (tuple, list)):
-                raise TypeError(f'Unknown index: {index} type: {type(index)}')
-            if len(index) > 2:
-                raise ValueError(f'index of len > 2 not allowed: {index}')
-            columns, samples = index
-            return self.get(columns, samples, except_missing=True)
+            else:
+                return self.get_in(index, except_missing=True)
 
-    def get(self, columns, samples, *, except_missing=False):
+    def get(self, keys, default=None, except_missing=False):
         """View of sample data across columns gracefully handling missing sample keys.
 
         Please see :meth:`__getitem__` for full description. This method is
@@ -239,22 +250,24 @@ class GetMixin:
         slot rather than throwing a ``KeyError`` like the dict style access
         does.
 
-        Parameters
-        ----------
-        columns: Union[str, Iterable[str], Ellipses, slice(None)]
-
-            Name(s) of the columns to query. The Ellipsis operator (``...``)
-            or unbounded slice operator (``:`` <==> ``slice(None)``) can be
-            used to indicate "select all" behavior.
-
-        samples: Union[str, int, Iterable[Union[str, int]]]
-
-            Names(s) of the samples to query
-
-        except_missing: bool, **KWARG ONLY**
-
-            If False, will not throw exceptions on missing sample key value.
-            Will raise KeyError if True and missing key found.
+        # TODO: Rewrite docstring
+        #
+        # Parameters
+        # ----------
+        # columns: Union[str, Iterable[str], Ellipses, slice(None)]
+        #
+        #     Name(s) of the columns to query. The Ellipsis operator (``...``)
+        #     or unbounded slice operator (``:`` <==> ``slice(None)``) can be
+        #     used to indicate "select all" behavior.
+        #
+        # samples: Union[str, int, Iterable[Union[str, int]]]
+        #
+        #     Names(s) of the samples to query
+        #
+        # except_missing: bool, **KWARG ONLY**
+        #
+        #     If False, will not throw exceptions on missing sample key value.
+        #     Will raise KeyError if True and missing key found.
 
         Returns
         -------
@@ -265,75 +278,55 @@ class GetMixin:
             Single column specified, single sample key specified
 
         List[Any]
-            Single column, multiple samples array data for each sample is
+            arbitrary columns, multiple samples array data for each sample is
             returned in same order sample keys are received.
-
-        List[NamedTuple[``*``Any]]
-            Multiple columns, multiple samples. Each column's name is used
-            as a field in the NamedTuple elements, each NamedTuple contains
-            arrays stored in each column via a common sample key. Each sample
-            key is returned values as an individual element in the
-            List. The sample order is returned in the same order it was received.
-
-        Warns
-        -----
-        UserWarning
-            Column names contains characters which are invalid as namedtuple fields.
         """
         with ExitStack() as stack:
             if not self._is_conman:
                 stack.enter_context(self)
 
-            # Column Parsing
-            if (columns is Ellipsis) or isinstance(columns, slice):
-                columns = list(self._columns._columns.values())
-            elif isinstance(columns, str):
-                columns = [self._columns._columns[columns]]
-            elif isinstance(columns, (tuple, list)):
-                columns = [self._columns._columns[aname] for aname in columns]
-            else:
-                raise TypeError(f'Columns index {columns} of type {type(columns)} invalid.')
-            nAsets = len(columns)
-            column_names = [col.column for col in columns]
-            try:
-                ColumnData = namedtuple('ColumnData', column_names)
-            except ValueError:
-                warnings.warn(
-                    'Column names contains characters which are invalid as namedtuple fields. '
-                    'All suspect field names will be replaced by their positional names '
-                    '(ie "_0" for element 0, "_4" for element 4)', UserWarning)
-                ColumnData = namedtuple('ColumnData', column_names, rename=True)
+            if isinstance(keys, str):
+                return self.columns[keys]
 
-            # Sample Parsing
-            if isinstance(samples, (str, int)):
-                samples = [samples]
-            elif not isinstance(samples, (tuple, list)):
-                raise TypeError(f'Samples index `{samples}` of type `{type(samples)}` invalid.')
-            nSamples = len(samples)
+            return self.get_in(keys, default, except_missing)
 
-            # Data Retrieval
-            columnsData = []
-            for col in columns:
-                column_samples = []
-                for sample in samples:
+    def get_in(self, keys, default=None, except_missing=False):
+        """Returns coll[i0][i1]...[iX] where [i0, i1, ..., iX]==keys.
+
+        If column[i0][i1]...[iX] cannot be found, returns ``default``, unless
+        ``except_missing`` is specified, then it raises KeyError or IndexError.
+
+        ``get_in`` is a generalization of ``operator.getitem`` for nested data
+        structures such as dictionaries and lists.
+
+        Parameters
+        ----------
+        keys
+        default
+        except_missing
+
+        Returns
+        -------
+
+        """
+        with ExitStack() as stack:
+            if not self._is_conman:
+                stack.enter_context(self)
+
+            if len(keys) >= 2 and any([isinstance(k, (list, tuple)) for k in keys]):
+                res = []
+                for key in keys:
                     try:
-                        arr = col[sample]
-                    except KeyError as e:
+                        res.append(reduce(op_getitem, key, self.columns))
+                    except (KeyError, IndexError, TypeError):
                         if except_missing:
-                            raise e
-                        arr = None
-                    column_samples.append(arr)
-                if nAsets == 1:
-                    columnsData = column_samples
-                    if nSamples == 1:
-                        columnsData = columnsData[0]
-                    break
-                columnsData.append(column_samples)
-            else:  # N.B. for-else conditional (ie. 'no break')
-                # noinspection PyUnresolvedReferences
-                tmp = map(ColumnData._make, zip(*columnsData))
-                columnsData = list(tmp)
-                if len(columnsData) == 1:
-                    columnsData = columnsData[0]
-
-            return columnsData
+                            raise
+                        res.append(default)
+                return res
+            else:
+                try:
+                    return reduce(op_getitem, keys, self.columns)
+                except (KeyError, IndexError, TypeError):
+                    if except_missing:
+                        raise
+                    return default

--- a/src/hangar/mixins/datasetget.py
+++ b/src/hangar/mixins/datasetget.py
@@ -2,10 +2,6 @@ from functools import reduce
 from operator import getitem as op_getitem
 from contextlib import ExitStack
 
-from collections import namedtuple
-import warnings
-
-
 # noinspection PyUnresolvedReferences
 class GetMixin:
     """Mixin methods for the checkout object classes.
@@ -185,11 +181,11 @@ class GetMixin:
             returned in same order sample keys are received.
         """
         with ExitStack() as stack:
-            if not bool(self._enter_count):
+            if not self._is_conman:
                 stack.enter_context(self)
 
             if isinstance(keys, str):
-                return self._columns[keys]
+                return self.columns[keys]
 
             _COLUMNS = self._columns
             if len(keys) >= 2 and any([isinstance(k, (list, tuple)) for k in keys]):

--- a/src/hangar/optimized_utils.pxd
+++ b/src/hangar/optimized_utils.pxd
@@ -1,4 +1,6 @@
 
 cdef class SizedDict(dict):
-    cdef public int _maxsize
-    cdef public object _stack
+    cdef int _maxsize
+    cdef object _stack
+    cdef dict _data
+    cdef int _stack_size

--- a/src/hangar/optimized_utils.pxd
+++ b/src/hangar/optimized_utils.pxd
@@ -1,6 +1,6 @@
 
 cdef class SizedDict(dict):
-    cdef int _maxsize
-    cdef object _stack
-    cdef dict _data
-    cdef int _stack_size
+    cdef public int _maxsize
+    cdef public object _stack
+    cdef public dict _data
+    cdef public int _stack_size

--- a/src/hangar/optimized_utils.pyx
+++ b/src/hangar/optimized_utils.pyx
@@ -1,45 +1,159 @@
+
 from collections import deque
 
 
-cdef class SizedDict(dict):
+cdef class SizedDict:
     """Sized dictionary"""
 
     def __init__(self, int maxsize=1000):
-        dict.__init__(self)
+        self._data = dict()
         self._maxsize = maxsize
         self._stack = deque()
+        self._stack_size = 0
 
-    def __setitem__(self, name, value):
-        cdef int size_stack = len(self._stack)
+    @property
+    def maxsize(self):
+        return self._maxsize
 
-        if size_stack >= self._maxsize:
+    def __getstate__(self):
+        state = {
+            '_stack_size': self._stack_size,
+            '_maxsize': self._maxsize,
+            '_stack': self._stack,
+            '_data': self._data,
+        }
+        return state
+
+    def __setstate__(self, state):
+        for attr_name, attr_val in state.items():
+            setattr(self, attr_name, attr_val)
+
+    def __repr__(self):
+        return repr(self._data)
+
+    def __contains__(self, key):
+        """Return True if d has a key key, else False."""
+        cdef bint res
+        res = key in self._data
+        return res
+
+    def __getitem__(self, key):
+        """Return the item of d with key key. Raises a KeyError if key
+        is not in the map.
+        """
+        return self._data[key]
+
+    def get(self, key, default=None):
+        """Return the value for key if key is in the dictionary, else default.
+
+        If default is not given, it defaults to None, so that this method
+        never raises a KeyError.
+        """
+        return self._data.get(key, default)
+
+    def __len__(self):
+        """Return the number of items in the dictionary d.
+        """
+        return self._stack_size
+
+    def __iter__(self):
+        """Return an iterator over the keys of the dictionary.
+
+        This is a shortcut for iter(d.keys()).
+        """
+        return iter(self.keys())
+
+    def __setitem__(self, key, value):
+        """Set d[key] to value
+        """
+        cdef object k_pop
+
+        if self._stack_size >= self._maxsize:
             k_pop = self._stack.popleft()
-            dict.__delitem__(self, k_pop)
-        self._stack.append(name)
-        dict.__setitem__(self, name, value)
+            del self._data[k_pop]
+            self._stack_size = self._stack_size - 1
+        self._stack.append(key)
+        self._data[key] = value
+        self._stack_size = self._stack_size + 1
 
-    def __delitem__(self, name):
-        cdef int idx = 0
-        cdef int size_stack = len(self._stack)
+    def __delitem__(self, key):
+        """Remove d[key] from d. Raises a KeyError if key is not in the map.
+        """
+        del self._data[key]
+        self._stack.remove(key)
+        self._stack_size = self._stack_size - 1
 
-        dict.__delitem__(self, name)
-        for idx in range(size_stack):
-            key = self._stack[idx]
-            if key == name:
-                break
-        del self._stack[idx]
+    def keys(self):
+        """Return a new view of the dictionary’s keys."""
+        return self._data.keys()
 
-    def update(self, other):
-        if isinstance(other, dict):
-            for k, v in other.items():
-                self.__setitem__(k, v)
-        else:
-            for k, v in other:
-                self.__setitem__(k, v)
+    def values(self):
+        """Return a new view of the dictionary’s values."""
+        return self._data.values()
 
-    def setdefault(self, name, default=None):
+    def items(self):
+        """Return a new view of the dictionary’s items (``(key, value)`` pairs).
+        """
+        return self._data.items()
+
+    def clear(self):
+        """Remove all items from the dictionary.
+        """
+        self._stack.clear()
+        self._data.clear()
+        self._stack_size = 0
+
+    def pop(self, key, default=None):
+        """If key is in the dictionary, remove it and return its value,
+        else return default.
+
+        If default is not given and key is not in the dictionary, a KeyError is raised.
+        """
+        cdef bint has_default
+
+        has_default = not bool(default is None)
+        if key in self._data:
+            val = self._data.pop(key)
+            self._stack.remove(key)
+            self._stack_size = self._stack_size - 1
+        elif has_default:
+            val = default
+        return val
+
+    def popitem(self):
+        """Remove and return a (key, value) pair from the dictionary.
+        Pairs are returned in LIFO order.
+
+        popitem() is useful to destructively iterate over a dictionary,
+        as often used in set algorithms. If the dictionary is empty, calling
+        popitem() raises a KeyError.
+        """
+        cdef object lifo_key, lifo_val
+        lifo_key = self._stack.pop()
+        lifo_val = self._data.pop(lifo_key)
+        self._stack_size = self._stack_size - 1
+        return lifo_key, lifo_val
+
+    def update(self, object other):
+        """Update the dictionary with the key/value pairs from other, overwriting
+        existing keys. Return None.
+
+        update() accepts either another dictionary object or an iterable of
+        key/value pairs (as tuples or other iterables of length two). If keyword
+        arguments are specified, the dictionary is then updated with those
+        key/value pairs: d.update(red=1, blue=2).
+        """
+        if not isinstance(other, dict):
+            other = dict(other)
+        for k, v in other.items():
+            self[k] = v
+
+    def setdefault(self, object key, default=None):
+        """If key is in the dictionary, return its value. If not, insert key
+        with a value of default and return default. default defaults to None.
+        """
         try:
-            return self.__getitem__(name)
+            return self[key]
         except KeyError:
-            self.__setitem__(name, default)
+            self[key] = default
             return default

--- a/src/hangar/optimized_utils.pyx
+++ b/src/hangar/optimized_utils.pyx
@@ -15,19 +15,6 @@ cdef class SizedDict:
     def maxsize(self):
         return self._maxsize
 
-    def __getstate__(self):
-        state = {
-            '_stack_size': self._stack_size,
-            '_maxsize': self._maxsize,
-            '_stack': self._stack,
-            '_data': self._data,
-        }
-        return state
-
-    def __setstate__(self, state):
-        for attr_name, attr_val in state.items():
-            setattr(self, attr_name, attr_val)
-
     def __repr__(self):
         return repr(self._data)
 
@@ -66,8 +53,6 @@ cdef class SizedDict:
     def __setitem__(self, key, value):
         """Set d[key] to value
         """
-        cdef object k_pop
-
         if self._stack_size >= self._maxsize:
             k_pop = self._stack.popleft()
             del self._data[k_pop]
@@ -134,7 +119,7 @@ cdef class SizedDict:
         self._stack_size = self._stack_size - 1
         return lifo_key, lifo_val
 
-    def update(self, object other):
+    def update(self, other):
         """Update the dictionary with the key/value pairs from other, overwriting
         existing keys. Return None.
 
@@ -148,12 +133,12 @@ cdef class SizedDict:
         for k, v in other.items():
             self[k] = v
 
-    def setdefault(self, object key, default=None):
+    def setdefault(self, key, default=None):
         """If key is in the dictionary, return its value. If not, insert key
         with a value of default and return default. default defaults to None.
         """
         try:
-            return self[key]
+            return self._data[key]
         except KeyError:
             self[key] = default
             return default

--- a/src/hangar/records/summarize.py
+++ b/src/hangar/records/summarize.py
@@ -161,7 +161,7 @@ def details(env: lmdb.Environment, line_limit=100, line_length=100) -> StringIO:
     """
     buf = StringIO()
     buf.write('\n======================\n')
-    buf.write(f'{Path(env.path()).name}')
+    buf.write(f'{Path(env.path()).name}\n')
     try:
         buf.write(f'File Size: {format_bytes(file_size(Path(env.path())))}\n')
     except FileNotFoundError:

--- a/src/hangar/records/summarize.py
+++ b/src/hangar/records/summarize.py
@@ -4,13 +4,87 @@ from io import StringIO
 
 import lmdb
 
-from .commiting import get_commit_ancestors_graph, get_commit_spec, tmp_cmt_env
-from .heads import get_staging_branch_head, get_branch_head_commit
+from .commiting import (
+    get_commit_ancestors_graph,
+    get_commit_spec,
+    tmp_cmt_env,
+)
+from .heads import (
+    get_staging_branch_head,
+    get_branch_head_commit,
+    commit_hash_to_branch_name_map,
+)
 from .queries import RecordQuery
 from .hashs import HashQuery
 from ..diff import DiffOut, Changes
 from ..txnctx import TxnRegister
 from ..utils import format_bytes, file_size, folder_size, unique_everseen
+from ..diagnostics import graphing
+
+
+def log(branchenv: lmdb.Environment,
+        refenv: lmdb.Environment,
+        branch: str = None,
+        commit: str = None,
+        *,
+        return_contents: bool = False,
+        show_time: bool = False,
+        show_user: bool = False):
+    """Displays a pretty printed commit log graph to the terminal.
+
+    .. note::
+
+        For programatic access, the return_contents value can be set to true
+        which will retrieve relevant commit specifications as dictionary
+        elements.
+
+    Parameters
+    ----------
+    branchenv : lmdb.Environment
+        db storing information on named branch HEADS
+    refenv : lmdb.Environment
+        db storing full commit history refs (compressed).
+    branch : str, optional
+        The name of the branch to start the log process from. (Default value
+        = None)
+    commit : str, optional
+        The commit hash to start the log process from. (Default value = None)
+    return_contents : bool, optional, kwarg only
+        If true, return the commit graph specifications in a dictionary
+        suitable for programatic access/evaluation.
+    show_time : bool, optional, kwarg only
+        If true and return_contents is False, show the time of each commit
+        on the printed log graph
+    show_user : bool, optional, kwarg only
+        If true and return_contents is False, show the committer of each
+        commit on the printed log graph
+    Returns
+    -------
+    Optional[dict]
+        Dict containing the commit ancestor graph, and all specifications.
+    """
+    res = list_history(
+        refenv=refenv,
+        branchenv=branchenv,
+        branch_name=branch,
+        commit_hash=commit)
+    branchMap = dict(commit_hash_to_branch_name_map(branchenv=branchenv))
+
+    if return_contents:
+        for digest in list(branchMap.keys()):
+            if digest not in res['order']:
+                del branchMap[digest]
+        res['branch_heads'] = branchMap
+        return res
+    else:
+        g = graphing.Graph()
+        g.show_nodes(dag=res['ancestors'],
+                     spec=res['specs'],
+                     branch=branchMap,
+                     start=res['head'],
+                     order=res['order'],
+                     show_time=show_time,
+                     show_user=show_user)
 
 
 def list_history(refenv, branchenv, branch_name=None, commit_hash=None):

--- a/src/hangar/typesystem/__init__.py
+++ b/src/hangar/typesystem/__init__.py
@@ -6,5 +6,5 @@ from .pystring import StringVariableShape
 
 __all__ = [
     'Descriptor', 'OneOf', 'DictItems', 'EmptyDict', 'SizedIntegerTuple',
-    'checkedmeta', 'NdarrayVariableShape', 'NdarrayFixedShape', 'StringVariableShape'
+    'checkedmeta', 'NdarrayVariableShape', 'NdarrayFixedShape', 'StringVariableShape',
 ]

--- a/src/hangar/utils.py
+++ b/src/hangar/utils.py
@@ -8,11 +8,15 @@ from collections import deque
 from io import StringIO
 from itertools import tee, filterfalse, count
 from typing import Union
+import sys
 
 import blosc
 
-from . import __version__
-from .constants import DIR_HANGAR
+
+def is_64bits():
+    """bool indicating if running on atleast a 64 bit machine
+    """
+    return sys.maxsize > 2 ** 32
 
 
 def set_blosc_nthreads() -> int:  # pragma: no cover
@@ -409,6 +413,9 @@ def readme_contents(user_name: str, user_email: str) -> StringIO:
     StringIO
         Buffered string text ready to be sent to a file writer.
     """
+    from . import __version__
+    from .constants import DIR_HANGAR
+
     buf = StringIO()
     buf.write(f'This directory has been used to initialize a Hangar Repository\n')
     buf.write(f'\n')

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -486,6 +486,13 @@ class TestCheckout(object):
         assert icount == 2
         co.close()
 
+    @pytest.mark.parametrize('write', [True, False])
+    def test_checkout_log_method(self, repo_20_filled_samples, write):
+        repo_log = repo_20_filled_samples.log(return_contents=True)
+        co = repo_20_filled_samples.checkout(write=write)
+        co_log = co.log(return_contents=True)
+        co.close()
+        assert repo_log == co_log
 
 
 class TestBranchingMergingInCheckout(object):

--- a/tests/test_checkout_arrayset_access.py
+++ b/tests/test_checkout_arrayset_access.py
@@ -348,7 +348,7 @@ def test_writer_co_get_returns_none_on_nonexistant_sample_name(aset_samples_init
 
     array5by7[:] = 0
     wco.columns['writtenaset'][0] = array5by7
-    out = wco.get('writtenaset', 124)
+    out = wco.get(('writtenaset', 124))
     assert out is None
     wco.close()
 
@@ -632,16 +632,16 @@ def test_co_read_dunder_getitem_excepts_missing_sample(aset_samples_initialized_
 def test_co_read_get_except_missing_true_excepts_missing_sample(aset_samples_initialized_repo, write):
     co = aset_samples_initialized_repo.checkout(write=write)
     with pytest.raises(KeyError):
-        res = co.get('writtenaset', 0, except_missing=True)
+        res = co.get(('writtenaset', 0), except_missing=True)
     co.close()
 
 
 @pytest.mark.parametrize('write', [True, False])
 def test_co_read_get_except_missing_false_returns_none_on_missing_sample(aset_samples_initialized_repo, write):
     co = aset_samples_initialized_repo.checkout(write=write)
-    res_1 = co.get('writtenaset', 0)
+    res_1 = co.get(('writtenaset', 0))
     assert res_1 is None
-    res_2 = co.get('writtenaset', 0, except_missing=False)
+    res_2 = co.get(('writtenaset', 0), except_missing=False)
     assert res_2 is None
     co.close()
 
@@ -699,26 +699,26 @@ def test_writer_co_aset_cm_not_allow_remove_aset(aset_samples_initialized_repo, 
     wco.close()
 
 
-def test_writer_co_aset_instance_cm_not_allow_any_aset_removal(repo_20_filled_samples):
+def test_writer_co_column_instance_cm_not_allow_any_column_removal(repo_20_filled_samples):
 
     wco = repo_20_filled_samples.checkout(write=True)
-    asets = wco.columns
+    columns = wco.columns
     writtenaset = wco.columns['writtenaset']
     second_aset = wco.columns['second_aset']
 
     with second_aset:
         with pytest.raises(PermissionError):
-            asets.delete('writtenaset')
+            columns.delete('writtenaset')
         with pytest.raises(PermissionError):
-            asets.delete('second_aset')
+            columns.delete('second_aset')
         with pytest.raises(PermissionError):
             wco.columns.delete('writtenaset')
         with pytest.raises(PermissionError):
             wco.columns.delete('second_aset')
         with pytest.raises(PermissionError):
-            del asets['writtenaset']
+            del columns['writtenaset']
         with pytest.raises(PermissionError):
-            del asets['second_aset']
+            del columns['second_aset']
         with pytest.raises(PermissionError):
             del wco.columns['second_aset']
         with pytest.raises(PermissionError):
@@ -726,35 +726,35 @@ def test_writer_co_aset_instance_cm_not_allow_any_aset_removal(repo_20_filled_sa
 
     with writtenaset:
         with pytest.raises(PermissionError):
-            asets.delete('writtenaset')
+            columns.delete('writtenaset')
         with pytest.raises(PermissionError):
-            asets.delete('second_aset')
+            columns.delete('second_aset')
         with pytest.raises(PermissionError):
             wco.columns.delete('writtenaset')
         with pytest.raises(PermissionError):
             wco.columns.delete('second_aset')
         with pytest.raises(PermissionError):
-            del asets['writtenaset']
+            del columns['writtenaset']
         with pytest.raises(PermissionError):
-            del asets['second_aset']
+            del columns['second_aset']
         with pytest.raises(PermissionError):
             del wco.columns['second_aset']
         with pytest.raises(PermissionError):
             del wco.columns['written_aset']
 
-    with asets:
+    with columns:
         with pytest.raises(PermissionError):
-            asets.delete('writtenaset')
+            columns.delete('writtenaset')
         with pytest.raises(PermissionError):
-            asets.delete('second_aset')
+            columns.delete('second_aset')
         with pytest.raises(PermissionError):
             wco.columns.delete('writtenaset')
         with pytest.raises(PermissionError):
             wco.columns.delete('second_aset')
         with pytest.raises(PermissionError):
-            del asets['writtenaset']
+            del columns['writtenaset']
         with pytest.raises(PermissionError):
-            del asets['second_aset']
+            del columns['second_aset']
         with pytest.raises(PermissionError):
             del wco.columns['second_aset']
         with pytest.raises(PermissionError):
@@ -928,7 +928,7 @@ def test_reader_co_get_read_returns_none_nonexistant_sample_name(aset_samples_in
     wco.close()
 
     rco = aset_samples_initialized_repo.checkout()
-    out = rco.get('writtenaset', 124)
+    out = rco.get(('writtenaset', 124))
     assert out is None
     rco.close()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -155,6 +155,12 @@ def test_checkout_writer_branch_lock_held_errors(repo_20_filled_samples_meta):
     assert repo_20_filled_samples_meta.writer_lock_held is False
 
 
+def test_diff_command(repo_2_br_no_conf):
+    runner = CliRunner()
+    res = runner.invoke(cli.diff, ['master', 'testbranch'], obj=repo_2_br_no_conf)
+    assert res.exit_code == 0
+
+
 def test_commit_cli_message(repo_20_filled_samples_meta):
     co = repo_20_filled_samples_meta.checkout(write=True)
     co.metadata['newkeyhere'] = 'somevaluehere'
@@ -763,6 +769,25 @@ def test_start_server(managed_tmpdir):
         assert time.time() - startTime <= 1.8  # buffer to give it time to stop
         assert res.exit_code == 0
         assert 'Hangar Server Started' in res.stdout
+
+
+# ------------------------ Developer Commands --------------------------------
+
+
+def test_db_view_command(repo_20_filled_samples_meta):
+    repo = repo_20_filled_samples_meta
+    runner = CliRunner()
+    res = runner.invoke(cli.lmdb_record_details, ['-a'], obj=repo)
+
+    dbs_queried = 0
+    assert res.exit_code == 0
+    for line in res.stdout.splitlines():
+        if '.lmdb' in line:
+            dbs_queried += 1
+    assert dbs_queried == 6
+
+    res = runner.invoke(cli.lmdb_record_details, ['-a', '--limit', '10'], obj=repo)
+    assert res.exit_code == 0
 
 
 # =========================== External Plugin =================================

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,6 +27,8 @@ help_res = 'Usage: main [OPTIONS] COMMAND [ARGS]...\n'\
            '  clone        Initialize a repository at the current path and fetch updated...\n'\
            '  column       Operations for working with columns in the writer checkout.\n'\
            '  commit       Commits outstanding changes.\n'\
+           '  diff         Display diff of DEV commit/branch to MASTER commit/branch If\n'\
+           '               no...\n'\
            '  export       Export COLUMN sample data as it existed a STARTPOINT to some...\n'\
            '  fetch        Retrieve the commit history from REMOTE for BRANCH.\n'\
            '  fetch-data   Get data from REMOTE referenced by STARTPOINT (short-commit or...\n'\

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -410,3 +410,95 @@ class TestWriterDiff(object):
         co.commit('init aset')
         assert co.diff.status() == 'CLEAN'
         co.close()
+
+
+def test_repo_diff_method_branch_names(aset_samples_initialized_repo):
+    # t3
+    repo = aset_samples_initialized_repo
+    co = repo.checkout(write=True, branch='master')
+    co.add_ndarray_column(name='testing_aset', shape=(5, 7), dtype=np.float64)
+    co.commit('added aset')
+    co.close()
+    repo.create_branch('testbranch')
+
+    co = repo.checkout(write=True, branch='master')
+    del co.columns['testing_aset']
+    co.add_ndarray_column(name='testing_aset', shape=(7, 7), dtype=np.float64)
+    masterHEAD = co.commit('mutation from master')
+    co.close()
+
+    co = repo.checkout(write=True, branch='testbranch')
+    del co.columns['testing_aset']
+    co.add_ndarray_column(name='testing_aset', shape=(5, 7), dtype=np.float32)
+    devHEAD = co.commit('mutation from dev')
+    co.close()
+
+    co = repo.checkout(write=False, branch='master')
+    co_diff = co.diff.branch('testbranch')
+    co.close()
+
+    repo_diff = repo.diff('master', 'testbranch')
+    assert co_diff == repo_diff
+
+
+def test_repo_diff_method_commit_digests(aset_samples_initialized_repo):
+    # t3
+    repo = aset_samples_initialized_repo
+    co = repo.checkout(write=True, branch='master')
+    co.add_ndarray_column(name='testing_aset', shape=(5, 7), dtype=np.float64)
+    co.commit('added aset')
+    co.close()
+    repo.create_branch('testbranch')
+
+    co = repo.checkout(write=True, branch='master')
+    del co.columns['testing_aset']
+    co.add_ndarray_column(name='testing_aset', shape=(7, 7), dtype=np.float64)
+    masterHEAD = co.commit('mutation from master')
+    co.close()
+
+    co = repo.checkout(write=True, branch='testbranch')
+    del co.columns['testing_aset']
+    co.add_ndarray_column(name='testing_aset', shape=(5, 7), dtype=np.float32)
+    devHEAD = co.commit('mutation from dev')
+    co.close()
+
+    co = repo.checkout(write=False, branch='master')
+    co_diff = co.diff.commit(devHEAD)
+    co.close()
+
+    repo_diff = repo.diff(masterHEAD, devHEAD)
+    assert co_diff == repo_diff
+
+
+
+
+def test_repo_diff_method_one_branch_one_commit_digest(aset_samples_initialized_repo):
+    # t3
+    repo = aset_samples_initialized_repo
+    co = repo.checkout(write=True, branch='master')
+    co.add_ndarray_column(name='testing_aset', shape=(5, 7), dtype=np.float64)
+    co.commit('added aset')
+    co.close()
+    repo.create_branch('testbranch')
+
+    co = repo.checkout(write=True, branch='master')
+    del co.columns['testing_aset']
+    co.add_ndarray_column(name='testing_aset', shape=(7, 7), dtype=np.float64)
+    masterHEAD = co.commit('mutation from master')
+    co.close()
+
+    co = repo.checkout(write=True, branch='testbranch')
+    del co.columns['testing_aset']
+    co.add_ndarray_column(name='testing_aset', shape=(5, 7), dtype=np.float32)
+    devHEAD = co.commit('mutation from dev')
+    co.close()
+
+    co = repo.checkout(write=False, branch='master')
+    co_diff = co.diff.commit(devHEAD)
+    co.close()
+
+    repo_diff1 = repo.diff('master', devHEAD)
+    assert co_diff == repo_diff1
+
+    repo_diff2 = repo.diff(masterHEAD, 'testbranch')
+    assert co_diff == repo_diff2

--- a/tests/test_optimized_utils.py
+++ b/tests/test_optimized_utils.py
@@ -1,0 +1,210 @@
+import pytest
+
+from hangar.optimized_utils import SizedDict
+
+
+def test_sizeddict_maxsize_property():
+    d = SizedDict(maxsize=5)
+    assert d.maxsize == 5
+    d2 = SizedDict(maxsize=10)
+    assert d2.maxsize == 10
+
+
+def test_sizeddict_setitem_no_overflow_retains_keys_and_len():
+    d = SizedDict(maxsize=5)
+    for i in range(5):
+        d[i] = i
+
+    assert len(d) == 5
+    for i in range(5):
+        assert i in d
+        assert d[i] == i
+
+
+def test_sizeddict_setitem_overflow_truncates_keys_and_len():
+    d = SizedDict(maxsize=5)
+    for i in range(10):
+        d[i] = i
+
+    assert len(d) == 5
+    for i in range(0, 5):
+        assert i not in d
+        with pytest.raises(KeyError):
+            _ = d[i]
+    for i in range(5, 10):
+        assert i in d
+        assert d[i] == i
+
+
+def test_sizeddict_update_no_overflow_retains_keys_and_len():
+    d = SizedDict(maxsize=5)
+    inp = {i: i for i in range(5)}
+    d.update(inp)
+
+    assert len(d) == 5
+    for i in range(5):
+        assert i in d
+        assert d[i] == i
+
+
+def test_sizeddict_updateoverflow_truncates_keys_and_len():
+    d = SizedDict(maxsize=5)
+    inp = {i: i for i in range(10)}
+    d.update(inp)
+
+    assert len(d) == 5
+    for i in range(0, 5):
+        assert i not in d
+        with pytest.raises(KeyError):
+            _ = d[i]
+    for i in range(5, 10):
+        assert i in d
+        assert d[i] == i
+
+
+def test_sizeddict_get_returns_default_on_missing_key():
+    d = SizedDict()
+    res = d.get('doesnotexist')
+    assert res is None
+    res = d.get('doesnotexist', default='foo')
+    assert res == 'foo'
+
+
+def test_sizeddict_delitem():
+    d = SizedDict(maxsize=5)
+    inp = {i: i for i in range(5)}
+    d.update(inp)
+
+    del d[3]
+    assert len(d) == 4
+    assert 3 not in d
+
+    d['new'] = 'foo'
+    assert len(d) == 5
+    assert 'new' in d
+
+
+def test_sizeddict_pop():
+    d = SizedDict(maxsize=5)
+    inp = {i: i for i in range(5)}
+    d.update(inp)
+
+    res = d.pop(0)
+    assert res == 0
+    assert len(d) == 4
+    res = d.pop('doesnotexist', default='foo')
+    assert res == 'foo'
+    assert len(d) == 4
+
+
+def test_sizeddict_popitem():
+    d = SizedDict(maxsize=5)
+    inp = {i: i for i in range(5)}
+    d.update(inp)
+
+    res = d.popitem()
+    assert res == (4, 4)
+    assert len(d) == 4
+    res = d.popitem()
+    assert res == (3, 3)
+    assert len(d) == 3
+
+    d['foo'] = 'bar'
+    assert len(d) == 4
+    res = d.popitem()
+    assert res == ('foo', 'bar')
+    assert len(d) == 3
+
+
+def test_sizeddict_keys():
+    d = SizedDict(maxsize=5)
+    inp = {str(i): i for i in range(5)}
+    d.update(inp)
+
+    assert list(d.keys()) == list(inp.keys())
+    for res_k, expected_k in zip(d.keys(), inp.keys()):
+        assert res_k == expected_k
+
+
+def test_sizeddict_values():
+    d = SizedDict(maxsize=5)
+    inp = {str(i): i for i in range(5)}
+    d.update(inp)
+
+    assert list(d.values()) == list(inp.values())
+    for res_v, expected_v in zip(d.values(), inp.values()):
+        assert res_v == expected_v
+
+
+def test_sizeddict_keys():
+    d = SizedDict(maxsize=5)
+    inp = {str(i): i for i in range(5)}
+    d.update(inp)
+
+    assert list(d.items()) == list(inp.items())
+    for res_kv, expected_kv in zip(d.items(), inp.items()):
+        assert res_kv == expected_kv
+
+
+def test_sizeddict_setdefault():
+    d = SizedDict(maxsize=5)
+    inp = {i: i for i in range(5)}
+    d.update(inp)
+
+    res = d.setdefault('doesnotexist')
+    assert res is None
+    assert len(d) == 5
+    assert 'doesnotexist' in d
+    assert d['doesnotexist'] is None
+
+    res = d.setdefault('doesnotexist2', default=True)
+    assert res is True
+    assert len(d) == 5
+    assert 'doesnotexist2' in d
+    assert d['doesnotexist2'] is True
+
+    res = d.setdefault(2, default=True)
+    assert res == 2
+    assert len(d) == 5
+    assert 2 in d
+    assert d[2] == 2
+
+
+def test_sizeddict_clear():
+    d = SizedDict(maxsize=5)
+    inp = {i: i for i in range(5)}
+    d.update(inp)
+
+    assert len(d) == 5
+    d.clear()
+    assert len(d) == 0
+    assert len(d._stack) == 0
+    assert len(d._data) == 0
+    assert d._stack_size == 0
+    assert d._maxsize == 5
+
+
+def test_sizeddict_repr():
+    d = SizedDict(maxsize=5)
+    inp = {i: i for i in range(5)}
+    d.update(inp)
+
+    expected = repr(inp)
+    res = repr(d)
+    assert res == expected
+
+
+def test_sizeddict_is_pickleable():
+    import pickle
+
+    d = SizedDict(maxsize=5)
+    inp = {i: i for i in range(5)}
+    d.update(inp)
+
+    pick = pickle.dumps(d, protocol=pickle.HIGHEST_PROTOCOL)
+    res = pickle.loads(pick)
+
+    assert res._maxsize == d._maxsize
+    assert res._stack == d._stack
+    assert res._stack_size == d._stack_size
+    assert res._data == d._data

--- a/tox.ini
+++ b/tox.ini
@@ -66,7 +66,7 @@ deps =
     -r{toxinidir}/docs/requirements.txt
 commands =
     sphinx-build {posargs:-E} -b html docs dist/docs
-    sphinx-build -b linkcheck docs dist/docs -j4
+    sphinx-build -b linkcheck docs dist/docs -j8
 install_command =
     pip install {packages} -f https://download.pytorch.org/whl/torch_stable.html
 


### PR DESCRIPTION
## Motivation and Context
#### _Why is this change required? What problem does it solve?:_

Added numerous convenience methods for general usage, major changes to the checkout column data reader API to allow support of arbitrary column layouts.

## Description
#### _Describe your changes in detail:_

- Added `log` method to checkout instances
- added `diff` method to `Repository` class
- added CLI `diff` command

##### API Changes to Checkout `__getitem__()` and `get()` methods. 

Checkout object can be thought of as a "dataset" ("dset") mapping a
view of samples across columns.

```python
>>> dset = repo.checkout(branch='master')
>>>
# Get an column contained in the checkout.
>>> dset['foo']
ColumnDataReader
>>>
# Get a specific sample from ``'foo'`` (returns a single array)
>>> dset['foo', '1']
np.array([1])
>>>
# Get multiple samples from ``'foo'`` (returns a list of arrays, in order
# of input keys)
>>> dset[['foo', '1'], ['foo', '2'],  ['foo', '324']]
[np.array([1]), np.ndarray([2]), np.ndarray([324])]
>>>
# Get sample from multiple columns, column/data returned is ordered
# in same manner as input of func.
>>> dset[['foo', '1'], ['bar', '1'],  ['baz', '1']]
[np.array([1]), np.ndarray([1, 1]), np.ndarray([1, 1, 1])]
>>>
# Get multiple samples from multiple columns\
>>> keys = [(col, str(samp)) for samp in range(2) for col in ['foo', 'bar']]
>>> keys
[('foo', '0'), ('bar', '0'), ('foo', '1'), ('bar', '1')]
>>> dset[keys]
[np.array([1]), np.array([1, 1]), np.array([2]), np.array([2, 2])]
```

Arbitrary column layouts are supported by simply adding additional members
to the keys for each piece of data. For example, getting data from a column
with a nested layout:

```python
>> dset['nested_col', 'sample_1', 'subsample_0']
np.array([1, 0])
>>>
# a sample accessor object can be retrieved at will...
>>> dset['nested_col', 'sample_1']
<class 'FlatSubsampleReader'>(column_name='nested_col', sample_name='sample_1')
>>>
# to get all subsamples in a nested sample use the Ellipsis operator
>>> dset['nested_col', 'sample_1', ...]
{'subsample_0': np.array([1, 0]),
 'subsample_1': np.array([1, 1]),
 ...
 'subsample_n': np.array([1, 255])}
```

Retrieval of data from different column types can be mixed and combined
as desired. For example, retrieving data from both flat and nested columns
simultaneously:

```python
>>> dset[('nested_col', 'sample_1', '0'), ('foo', '0')]
[np.array([1, 0]), np.array([0])]
>>> dset[('nested_col', 'sample_1', ...), ('foo', '0')]
[{'subsample_0': np.array([1, 0]), 'subsample_1': np.array([1, 1])},
 np.array([0])]
>>> dset[('foo', '0'), ('nested_col', 'sample_1')]
[np.array([0]),
 <class 'FlatSubsampleReader'>(column_name='nested_col', sample_name='sample_1')]
```

If a column or data key does not exist, then this method will raise a KeyError.
As an alternative, missing keys can be gracefully handeled by calling :meth:`get()`
instead. This method does not (by default) raise an error if a key is missing.
Instead, a (configurable) default value is simply inserted in it's place.

```python
>>> dset['foo', 'DOES_NOT_EXIST']
-------------------------------------------------------------------
KeyError                           Traceback (most recent call last)
<ipython-input-40-731e6ea62fb8> in <module>
----> 1 res = co['foo', 'DOES_NOT_EXIST']
KeyError: 'DOES_NOT_EXIST'
```

## Screenshots (if appropriate):

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Documentation update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Is this PR ready for review, or a work in progress?
- [ ] Ready for review
- [x] Work in progress

## How Has This Been Tested?
Put an `x` in the boxes that apply:
- [ ] Current tests cover modifications made
- [x] New tests have been added to the test suite
- [x] Modifications were made to existing tests to support these changes
- [ ] Tests may be needed, but they are not included when the PR was proposed
- [ ] I don't know. Help!

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.rst)** document.
- [x] I have signed (or will sign when prompted) the tensorwork CLA.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
