### PR TITLE
New Feature: Bytes Data Type Column

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     container: quay.io/pypa/manylinux2014_x86_64
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - name: Install Python package dependencies
       run: /opt/python/cp36-cp36m/bin/python -m pip install cython wheel setuptools
     - name: Build binary wheel
@@ -30,7 +30,7 @@ jobs:
     container: quay.io/pypa/manylinux2014_x86_64
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - name: Install Python package dependencies
       run: /opt/python/cp37-cp37m/bin/python -m pip install cython wheel setuptools
     - name: Build binary wheel
@@ -50,7 +50,7 @@ jobs:
     container: quay.io/pypa/manylinux2014_x86_64
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - name: Install Python package dependencies
       run: /opt/python/cp38-cp38/bin/python -m pip install cython wheel setuptools
     - name: Build binary wheel
@@ -73,7 +73,7 @@ jobs:
         python-version: [3.6, 3.7, 3.8]
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }} x64
       uses: actions/setup-python@v1
       with:
@@ -97,7 +97,7 @@ jobs:
         python-version: [3.6, 3.7, 3.8]
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - name: Download Build Tools for Visual Studio 2019
       run: Invoke-WebRequest -Uri https://aka.ms/vs/16/release/vs_buildtools.exe -OutFile vs_buildtools.exe
     - name: Run vs_buildtools.exe install

--- a/.github/workflows/testsphinx.yml
+++ b/.github/workflows/testsphinx.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Set up Python 3.7
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -31,7 +31,7 @@ jobs:
             python-version: 3.7
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,23 @@ Change Log
 ==========
 
 
+_`In-Progress`
+==============
+
+New Features
+------------
+
+* New column data type supporting arbitrary ``bytes`` data.
+  (`#198 <https://github.com/tensorwerk/hangar-py/pull/198>`__) `@rlizzo <https://github.com/rlizzo>`__
+
+Improvements
+------------
+
+* ``str`` typed columns can now accept data containing any unicode code-point. In prior releases
+  data containing any ``non-ascii`` character could not be written to this column type.
+  (`#198 <https://github.com/tensorwerk/hangar-py/pull/198>`__) `@rlizzo <https://github.com/rlizzo>`__
+
+
 `0.5.1`_ (2020-04-05)
 =====================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,15 @@ Improvements
   (`#198 <https://github.com/tensorwerk/hangar-py/pull/198>`__) `@rlizzo <https://github.com/rlizzo>`__
 
 
+Bug Fixes
+---------
+
+* Fixed issue where ``str`` and (newly added) ``bytes`` column data could not be fetched / pushed
+  between a local client repository and remote server.
+  (`#198 <https://github.com/tensorwerk/hangar-py/pull/198>`__) `@rlizzo <https://github.com/rlizzo>`__
+
+
+
 `0.5.1`_ (2020-04-05)
 =====================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,6 @@ addopts =
     --ignore=setup.py
     --ignore=.eggs
     --tb=auto
-    --dist=loadscope
 
 [isort]
 force_single_line = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ addopts =
     --ignore=setup.py
     --ignore=.eggs
     --tb=auto
+    --dist=loadscope
 
 [isort]
 force_single_line = True

--- a/src/hangar/_version.py
+++ b/src/hangar/_version.py
@@ -19,6 +19,8 @@ import re
 from collections import namedtuple
 from itertools import dropwhile
 from typing import Callable, Optional, SupportsInt, Tuple, Union
+from operator import lt, le, eq, ge, gt, ne
+
 
 __all__ = ["parse", "Version", "InvalidVersion", "VERSION_PATTERN"]
 
@@ -146,29 +148,28 @@ class _BaseVersion(object):
         return hash(self._key)
 
     def __lt__(self, other: '_BaseVersion') -> bool:
-        return self._compare(other, lambda s, o: s < o)
+        return self._compare(other, lt)
 
     def __le__(self, other: '_BaseVersion') -> bool:
-        return self._compare(other, lambda s, o: s <= o)
+        return self._compare(other, le)
 
     def __eq__(self, other: object) -> bool:
-        return self._compare(other, lambda s, o: s == o)
+        return self._compare(other, eq)
 
     def __ge__(self, other: '_BaseVersion') -> bool:
-        return self._compare(other, lambda s, o: s >= o)
+        return self._compare(other, ge)
 
     def __gt__(self, other: '_BaseVersion') -> bool:
-        return self._compare(other, lambda s, o: s > o)
+        return self._compare(other, gt)
 
     def __ne__(self, other: object) -> bool:
-        return self._compare(other, lambda s, o: s != o)
+        return self._compare(other, ne)
 
     def _compare(self, other: object, method: VersionComparisonMethod
                  ) -> Union[bool, type(NotImplemented)]:
-        if not isinstance(other, _BaseVersion):
-            return NotImplemented
-
-        return method(self._key, other._key)
+        if isinstance(other, _BaseVersion):
+            return method(self._key, other._key)
+        return NotImplemented
 
 
 # Deliberately not anchored to the start and end of the string, to make it
@@ -213,11 +214,11 @@ class Version(_BaseVersion):  # lgtm [py/missing-equals]
 
     def __init__(self, version: str) -> None:
         super().__init__()
-        
+
         # Validate the version and parse it into pieces
         match = _REGEX.search(version)
         if not match:
-            raise InvalidVersion("Invalid version: '{0}'".format(version))
+            raise InvalidVersion(f"Invalid version: '{version}'")
 
         # Store the parsed out pieces of the version
         self._version = _Version(
@@ -242,14 +243,14 @@ class Version(_BaseVersion):  # lgtm [py/missing-equals]
         )
 
     def __repr__(self) -> str:
-        return "<Version({0})>".format(repr(str(self)))
+        return f"<Version({repr(str(self))})>"
 
     def __str__(self) -> str:
         parts = []
 
         # Epoch
         if self.epoch != 0:
-            parts.append("{0}!".format(self.epoch))
+            parts.append(f"{self.epoch}!")
 
         # Release segment
         parts.append(".".join(str(x) for x in self.release))
@@ -260,15 +261,15 @@ class Version(_BaseVersion):  # lgtm [py/missing-equals]
 
         # Post-release
         if self.post is not None:
-            parts.append(".post{0}".format(self.post))
+            parts.append(f".post{self.post}")
 
         # Development release
         if self.dev is not None:
-            parts.append(".dev{0}".format(self.dev))
+            parts.append(f".dev{self.dev}")
 
         # Local version segment
         if self.local is not None:
-            parts.append("+{0}".format(self.local))
+            parts.append(f"+{self.local}")
 
         return "".join(parts)
 
@@ -312,7 +313,7 @@ class Version(_BaseVersion):  # lgtm [py/missing-equals]
 
         # Epoch
         if self.epoch != 0:
-            parts.append("{0}!".format(self.epoch))
+            parts.append(f"{self.epoch}!")
 
         # Release segment
         parts.append(".".join(str(x) for x in self.release))

--- a/src/hangar/backends/__init__.py
+++ b/src/hangar/backends/__init__.py
@@ -91,6 +91,7 @@ from .specs import (
     HDF5_01_DataHashSpec,
     NUMPY_10_DataHashSpec,
     LMDB_30_DataHashSpec,
+    LMDB_31_DataHashSpec,
     REMOTE_50_DataHashSpec,
 )
 from .specparse import backend_decoder
@@ -98,6 +99,7 @@ from .specparse import backend_decoder
 from .hdf5_00 import HDF5_00_FileHandles, HDF5_00_Options
 from .hdf5_01 import HDF5_01_FileHandles, HDF5_01_Options
 from .lmdb_30 import LMDB_30_FileHandles, LMDB_30_Options
+from .lmdb_31 import LMDB_31_FileHandles, LMDB_31_Options
 from .numpy_10 import NUMPY_10_FileHandles, NUMPY_10_Options
 from .remote_50 import REMOTE_50_Handler, REMOTE_50_Options
 
@@ -108,6 +110,7 @@ BACKEND_ACCESSOR_MAP = {
     '01': HDF5_01_FileHandles,
     '10': NUMPY_10_FileHandles,
     '30': LMDB_30_FileHandles,
+    '31': LMDB_31_FileHandles,
     # REMOTES -> [50:99] + ['AA':'ZZ']
     '50': REMOTE_50_Handler,
 }
@@ -117,6 +120,7 @@ BACKEND_OPTIONS_MAP = {
     '01': HDF5_01_Options,
     '10': NUMPY_10_Options,
     '30': LMDB_30_Options,
+    '31': LMDB_31_Options,
     '50': REMOTE_50_Options,
 }
 
@@ -129,5 +133,6 @@ BACKEND_IS_LOCAL_MAP: Dict[str, bool] = {
 __all__ = [
     'backend_decoder', 'HDF5_00_DataHashSpec', 'HDF5_01_DataHashSpec',
     'NUMPY_10_DataHashSpec', 'LMDB_30_DataHashSpec', 'REMOTE_50_DataHashSpec',
-    'BACKEND_OPTIONS_MAP', 'BACKEND_ACCESSOR_MAP', 'BACKEND_IS_LOCAL_MAP',
+    'LMDB_31_DataHashSpec', 'BACKEND_OPTIONS_MAP', 'BACKEND_ACCESSOR_MAP',
+    'BACKEND_IS_LOCAL_MAP',
 ]

--- a/src/hangar/backends/lmdb_31.py
+++ b/src/hangar/backends/lmdb_31.py
@@ -1,0 +1,407 @@
+"""Local LMDB Backend Implementation, Identifier: ``LMDB_30``
+
+Backend Identifiers
+===================
+
+*  Backend: ``3``
+*  Version: ``1``
+*  Format Code: ``31``
+*  Canonical Name: ``LMDB_31``
+
+Storage Method
+==============
+
+*  This module is meant to handle bbytes typed data which is of any size.
+   less than 2MB per value. IO is performed via the LMDB storage system.
+
+*  This module does not compress values upon writing, the full (uncompressed)
+   value of the text is written to the DB for each key.
+
+*  For each LMDB file generated, data is indexed by keys which are generated
+   in lexicographically sorted order of key length 4. Keys consist of 4 characters
+   chosen from an alphabet consisting of ASCII digits, lowercase letters, and
+   upercase letters. Within a single write instance (when an LMDB file is created
+   and written to), lexicographically sorted permutations of the chosen characters
+   are used as key indexes.
+
+   This means that for each LMDB file written in a repo, the sequence of generated
+   index keys will be identical, even though two databases with the same key will
+   store different values. As such, the File UID is crucial in order to identify
+   a unique db/index key combo to access a particular value by.
+
+*  There is no limit to the size which each record can occupy. Data is stored
+   "as-is" and is uncompressed. Reading the data back will return the exact
+   data stored (regardless of how large the data record is).
+
+*  On read and write of all samples the xxhash64_hexdigest is calculated for
+   the raw data bytes. This is to ensure that all data in == data out of the
+   lmdb files. That way even if a file is manually edited we have a quick way
+   to tell that things are not as they should be. (full data hash digests may
+   not be calculated every time a read is performed).
+
+Compression Options
+===================
+
+None
+
+Record Format
+=============
+
+Fields Recorded for Each Array
+------------------------------
+
+*  Format Code
+*  File UID
+*  Row Index
+
+Examples
+--------
+
+1)  Adding the first piece of data to a file:
+
+    *  File UID: "rlUK3C"
+    *  Row Index: "0123"
+    *  xxhash64_hexdigest: 8067007c0f05c359
+
+    ``Record Data => "31:rlUK3C:0123:8067007c0f05c359"``
+
+2)  Adding a second piece of data:
+
+    *  File UID: "rlUK3C"
+    *  Row Index: "0124"
+    *  xxhash64_hexdigest: b89f873d3d153a9c
+
+    ``Record Data => "31:rlUK3C:0124:b89f873d3d153a9c"``
+
+3)  Adding a the 500th piece of data:
+
+    *  File UID: "rlUK3C"
+    *  Row Index: "01AU"
+    *  xxhash64_hexdigest: cf3fc53cad153a5a
+
+    ``Record Data => "31:rlUK3C:01AU:cf3fc53cad153a5a"``
+"""
+import os
+import shutil
+import string
+from collections import ChainMap
+from contextlib import suppress
+from functools import partial
+from itertools import permutations
+from pathlib import Path
+from typing import Optional
+
+import lmdb
+from xxhash import xxh64_hexdigest
+
+from .specs import LMDB_31_DataHashSpec
+from ..constants import DIR_DATA_REMOTE, DIR_DATA_STAGE, DIR_DATA_STORE, DIR_DATA
+from ..op_state import reader_checkout_only, writer_checkout_only
+from ..utils import random_string
+from ..typesystem import Descriptor, OneOf, EmptyDict, checkedmeta
+
+
+LMDB_SETTINGS = {
+    'map_size': 300_000_000,
+    'meminit': False,
+    'subdir': True,
+    'lock': True,
+    'max_spare_txns': 4,
+}
+_FmtCode = '31'
+
+
+def _lexicographic_keys():
+    lexicographic_ids = ''.join([
+        string.digits,
+        string.ascii_uppercase,
+        string.ascii_lowercase,
+    ])
+    # permutations generates results in lexicographic order
+    # total of 14_776_336 total ids can be generated with
+    # a row_id consisting of 4 characters. This is more keys than
+    # we will ever allow in a single LMDB database
+    p = permutations(lexicographic_ids, 4)
+
+    for perm in p:
+        res = ''.join(perm)
+        yield res
+
+
+def lmdb_31_encode(uid: str, row_idx: int, checksum: str) -> bytes:
+    res = f'31:{uid}:{row_idx}:{checksum}'
+    return res.encode()
+
+
+@OneOf(['<class\'bytes\'>', bytes])
+class AllowedDtypes(Descriptor):
+    pass
+
+
+class LMDB_31_Options(metaclass=checkedmeta):
+    _dtype = AllowedDtypes()
+    _backend_options = EmptyDict()
+
+    def __init__(self, backend_options, dtype, *args, **kwargs):
+        if backend_options is None:
+            backend_options = self.default_options
+        self._backend_options = backend_options
+        self._dtype = dtype
+
+    @property
+    def default_options(self):
+        return {}
+
+    @property
+    def backend_options(self):
+        return self._backend_options
+
+    @property
+    def init_requires(self):
+        return ('repo_path',)
+
+
+class LMDB_31_FileHandles:
+
+    def __init__(self, repo_path: Path, *args, **kwargs):
+
+        self.path: Path = repo_path
+
+        self.rFp = {}
+        self.wFp = {}
+        self.Fp = ChainMap(self.rFp, self.wFp)
+
+        self.mode: Optional[str] = None
+        self.w_uid: Optional[str] = None
+        self.row_idx: Optional[str] = None
+        self._dflt_backend_opts: Optional[dict] = None
+
+        self.STAGEDIR: Path = Path(self.path, DIR_DATA_STAGE, _FmtCode)
+        self.REMOTEDIR: Path = Path(self.path, DIR_DATA_REMOTE, _FmtCode)
+        self.STOREDIR: Path = Path(self.path, DIR_DATA_STORE, _FmtCode)
+        self.DATADIR: Path = Path(self.path, DIR_DATA, _FmtCode)
+        self.DATADIR.mkdir(exist_ok=True)
+
+    def __enter__(self):
+
+        return self
+
+    def __exit__(self, *exc):
+        return
+
+    @reader_checkout_only
+    def __getstate__(self) -> dict:
+        """ensure multiprocess operations can pickle relevant data.
+        """
+        self.close()
+        state = self.__dict__.copy()
+        del state['rFp']
+        del state['wFp']
+        del state['Fp']
+        return state
+
+    def __setstate__(self, state: dict) -> None:  # pragma: no cover
+        """ensure multiprocess operations can pickle relevant data.
+        """
+        self.__dict__.update(state)
+        self.rFp = {}
+        self.wFp = {}
+        self.Fp = ChainMap(self.rFp, self.wFp)
+
+    @property
+    def backend_opts(self):
+        return self._dflt_backend_opts
+
+    @writer_checkout_only
+    def _backend_opts_set(self, val):
+        """Nonstandard descriptor method. See notes in ``backend_opts.setter``.
+        """
+        self._dflt_backend_opts = val
+        return
+
+    @backend_opts.setter
+    def backend_opts(self, value):
+        """
+        Using seperate setter method (with ``@writer_checkout_only`` decorator
+        applied) due to bug in python <3.8.
+
+        From: https://bugs.python.org/issue19072
+            > The classmethod decorator when applied to a function of a class,
+            > does not honour the descriptor binding protocol for whatever it
+            > wraps. This means it will fail when applied around a function which
+            > has a decorator already applied to it and where that decorator
+            > expects that the descriptor binding protocol is executed in order
+            > to properly bind the function to the class.
+        """
+        return self._backend_opts_set(value)
+
+    def open(self, mode: str, *, remote_operation: bool = False):
+        """Open an lmdb file handle.
+
+        Parameters
+        ----------
+        mode : str
+            one of `r` or `a` for read only / read-write.
+        remote_operation : optional, kwarg only, bool
+            if this lmdb data is being created from a remote fetch operation, then
+            we don't open any files for reading, and only open files for writing
+            which exist in the remote data dir. (default is false, which means that
+            write operations use the stage data dir and read operations use data store
+            dir)
+        """
+        self.mode = mode
+        if self.mode == 'a':
+            process_dir = self.REMOTEDIR if remote_operation else self.STAGEDIR
+            process_dir.mkdir(exist_ok=True)
+            for uidpth in process_dir.iterdir():
+                if uidpth.suffix == '.lmdbdir':
+                    file_pth = self.DATADIR.joinpath(uidpth.stem)
+                    self.rFp[uidpth.stem] = partial(
+                        lmdb.open, str(file_pth), readonly=True, **LMDB_SETTINGS)
+
+        if not remote_operation:
+            if not self.STOREDIR.is_dir():
+                return
+            for uidpth in self.STOREDIR.iterdir():
+                if uidpth.suffix == '.lmdbdir':
+                    file_pth = self.DATADIR.joinpath(uidpth.stem)
+                    self.rFp[uidpth.stem] = partial(
+                        lmdb.open, str(file_pth), readonly=True, **LMDB_SETTINGS)
+
+    def close(self):
+        """Close a file handle after writes have been completed
+
+        behavior changes depending on write-enable or read-only file
+
+        Returns
+        -------
+        bool
+            True if success, otherwise False.
+        """
+        if self.mode == 'a':
+            for uid in list(self.wFp.keys()):
+                with suppress(AttributeError):
+                    self.wFp[uid].close()
+                del self.wFp[uid]
+            self.w_uid = None
+            self.row_idx = None
+
+        for uid in list(self.rFp.keys()):
+            with suppress(AttributeError):
+                self.rFp[uid].close()
+            del self.rFp[uid]
+
+    @staticmethod
+    def delete_in_process_data(repo_path: Path, *, remote_operation=False) -> None:
+        """Removes some set of files entirely from the stage/remote directory.
+
+        DANGER ZONE. This should essentially only be used to perform hard resets
+        of the repository state.
+
+        Parameters
+        ----------
+        repo_path : Path
+            path to the repository on disk
+        remote_operation : optional, kwarg only, bool
+            If true, modify contents of the remote_dir, if false (default) modify
+            contents of the staging directory.
+        """
+        data_dir = Path(repo_path, DIR_DATA, _FmtCode)
+        PDIR = DIR_DATA_STAGE if not remote_operation else DIR_DATA_REMOTE
+        process_dir = Path(repo_path, PDIR, _FmtCode)
+        if not process_dir.is_dir():
+            return
+
+        for uidpth in process_dir.iterdir():
+            if uidpth.suffix == '.lmdbdir':
+                os.remove(process_dir.joinpath(uidpth.name))
+                db_dir = data_dir.joinpath(uidpth.stem)
+                shutil.rmtree(str(db_dir))
+        os.rmdir(process_dir)
+
+    def _create_schema(self, *, remote_operation: bool = False):
+
+        uid = random_string()
+        db_dir_path = self.DATADIR.joinpath(f'{uid}')
+        self.wFp[uid] = lmdb.open(str(db_dir_path), **LMDB_SETTINGS)
+
+        self.w_uid = uid
+        self.row_idx = _lexicographic_keys()
+
+        process_dir = self.REMOTEDIR if remote_operation else self.STAGEDIR
+        Path(process_dir, f'{uid}.lmdbdir').touch()
+
+    def read_data(self, hashVal: LMDB_31_DataHashSpec) -> str:
+        """Read data from an hdf5 file handle at the specified locations
+
+        Parameters
+        ----------
+        hashVal : LMDB_31_DataHashSpec
+            record specification parsed from its serialized store val in lmdb.
+
+        Returns
+        -------
+        str
+            requested data.
+        """
+        try:
+            with self.Fp[hashVal.uid].begin(write=False) as txn:
+                res = txn.get(hashVal.row_idx.encode(), default=False)
+                if res is False:
+                    raise RuntimeError(hashVal)
+        except AttributeError:
+            self.Fp[hashVal.uid] = self.Fp[hashVal.uid]()
+            return self.read_data(hashVal)
+        except KeyError:
+            process_dir = self.STAGEDIR if self.mode == 'a' else self.STOREDIR
+            if Path(process_dir, f'{hashVal.uid}.lmdbdir').is_file():
+                file_pth = self.DATADIR.joinpath(hashVal.uid)
+                self.rFp[hashVal.uid] = lmdb.open(str(file_pth), readonly=True, **LMDB_SETTINGS)
+                return self.read_data(hashVal)
+            else:
+                raise
+
+        if xxh64_hexdigest(res) != hashVal.checksum:
+            raise RuntimeError(
+                f'DATA CORRUPTION Checksum {xxh64_hexdigest(res)} != recorded {hashVal}')
+        return res
+
+    def write_data(self, data: bytes, *, remote_operation: bool = False) -> bytes:
+        """verifies correctness of array data and performs write operation.
+
+        Parameters
+        ----------
+        data: bytes
+            data to write to group.
+        remote_operation : optional, kwarg only, bool
+            If this is a remote process which is adding data, any necessary
+            hdf5 dataset files will be created in the remote data dir instead
+            of the stage directory. (default is False, which is for a regular
+            access process)
+
+        Returns
+        -------
+        bytes
+            string identifying the collection dataset and collection dim-0 index
+            which the array can be accessed at.
+        """
+        checksum = xxh64_hexdigest(data)
+        if self.w_uid in self.wFp:
+            try:
+                row_idx = next(self.row_idx)
+            except StopIteration:
+                self._create_schema(remote_operation=remote_operation)
+                return self.write_data(data, remote_operation=remote_operation)
+        else:
+            self._create_schema(remote_operation=remote_operation)
+            return self.write_data(data, remote_operation=remote_operation)
+
+        encoded_row_idx = row_idx.encode()
+        try:
+            with self.wFp[self.w_uid].begin(write=True) as txn:
+                txn.put(encoded_row_idx, data, append=True)
+        except lmdb.MapFullError:
+            self._create_schema(remote_operation=remote_operation)
+            return self.write_data(data, remote_operation=remote_operation)
+
+        return lmdb_31_encode(self.w_uid, row_idx, checksum)

--- a/src/hangar/backends/specparse.pyx
+++ b/src/hangar/backends/specparse.pyx
@@ -4,6 +4,7 @@ from .specs cimport HDF5_01_DataHashSpec, \
     HDF5_00_DataHashSpec, \
     NUMPY_10_DataHashSpec, \
     LMDB_30_DataHashSpec, \
+    LMDB_31_DataHashSpec, \
     REMOTE_50_DataHashSpec
 
 
@@ -155,6 +156,29 @@ cdef LMDB_30_DataHashSpec LMDB_30_Parser(str inp):
     return res
 
 
+cdef LMDB_31_DataHashSpec LMDB_31_Parser(str inp):
+    cdef str fmt, uid, row_idx, checksum
+    cdef unsigned char i, c, cc
+    cdef unsigned char n = len(inp)
+    cdef LMDB_31_DataHashSpec res
+
+    c = 0
+    cc = 0
+    for i in range(n):
+        if inp[i] == ':':
+            if cc == 0:
+                fmt = inp[c:i]
+            elif cc == 1:
+                uid = inp[c:i]
+            elif cc == 2:
+                row_idx = inp[c:i]
+            c = i + 1
+            cc = cc + 1
+    checksum = inp[c:n]
+
+    res = LMDB_31_DataHashSpec(fmt, uid, row_idx, checksum)
+    return res
+
 
 cdef REMOTE_50_DataHashSpec REMOTE_50_Parser(str inp):
     cdef str fmt, schema_hash
@@ -184,6 +208,8 @@ cpdef object backend_decoder(bytes inp):
         return NUMPY_10_Parser(inp_str)
     elif backend == '30':
         return LMDB_30_Parser(inp_str)
+    elif backend == '31':
+        return LMDB_31_Parser(inp_str)
     elif backend == '50':
         return REMOTE_50_Parser(inp_str)
     else:

--- a/src/hangar/backends/specs.pxd
+++ b/src/hangar/backends/specs.pxd
@@ -37,6 +37,14 @@ cdef class LMDB_30_DataHashSpec:
     cdef readonly  str checksum
 
 
+cdef class LMDB_31_DataHashSpec:
+
+    cdef readonly str backend
+    cdef readonly str uid
+    cdef readonly str row_idx
+    cdef readonly  str checksum
+
+
 cdef class REMOTE_50_DataHashSpec:
 
     cdef readonly str backend

--- a/src/hangar/backends/specs.pyx
+++ b/src/hangar/backends/specs.pyx
@@ -115,6 +115,33 @@ cdef class LMDB_30_DataHashSpec:
         return True
 
 
+
+cdef class LMDB_31_DataHashSpec:
+
+    def __init__(self, str backend, str uid, str row_idx, str checksum):
+
+        self.backend = backend
+        self.uid = uid
+        self.row_idx = row_idx
+        self.checksum = checksum
+
+
+    def __repr__(self):
+        return (f'{self.__class__.__name__}('
+                f'backend="{self.backend}", '
+                f'uid="{self.uid}", '
+                f'row_idx={self.row_idx}, '
+                f'checksum="{self.checksum}")')
+
+    def __iter__(self):
+        for attr in ['backend', 'uid', 'row_idx', 'checksum']:
+            yield getattr(self, attr)
+
+    @property
+    def islocal(self):
+        return True
+
+
 cdef class REMOTE_50_DataHashSpec:
 
     def __init__(self, str backend, str schema_hash):

--- a/src/hangar/columns/constructors.py
+++ b/src/hangar/columns/constructors.py
@@ -15,7 +15,12 @@ from .layout_nested import (
 )
 from ..records.queries import RecordQuery
 from ..records import hash_data_db_key_from_raw_key
-from ..typesystem import NdarrayFixedShape, NdarrayVariableShape, StringVariableShape
+from ..typesystem import (
+    NdarrayFixedShape,
+    NdarrayVariableShape,
+    StringVariableShape,
+    BytesVariableShape
+)
 from ..backends import BACKEND_IS_LOCAL_MAP, backend_decoder
 
 
@@ -24,7 +29,12 @@ from ..backends import BACKEND_IS_LOCAL_MAP, backend_decoder
 
 KeyType = Union[str, int]
 
-_column_definitions = (NdarrayVariableShape, NdarrayFixedShape, StringVariableShape)
+_column_definitions = (
+    NdarrayVariableShape,
+    NdarrayFixedShape,
+    StringVariableShape,
+    BytesVariableShape
+)
 
 
 def column_type_object_from_schema(schema: dict):

--- a/src/hangar/columns/constructors.py
+++ b/src/hangar/columns/constructors.py
@@ -42,7 +42,7 @@ def column_type_object_from_schema(schema: dict):
         try:
             instance = c(**schema)
             return instance
-        except (TypeError, ValueError):
+        except (TypeError, ValueError) as e:
             pass
     else:  # N.B. for-else loop (ie. "no-break")
         raise ValueError(f'Could not instantiate column schema object for {schema}')

--- a/src/hangar/records/hashmachine.pyx
+++ b/src/hangar/records/hashmachine.pyx
@@ -16,6 +16,8 @@ cpdef object hash_func_from_tcode(str tcode):
         return schema_hasher_tcode_1
     elif tcode == '2':
         return pystr_hasher_tcode_2
+    elif tcode == '3':
+        return pybytes_hasher_tcode_3
     else:
         raise ValueError(f'unknown hash function type code. tcode: {tcode}')
 
@@ -112,17 +114,17 @@ cpdef str schema_hasher_tcode_1(dict schema):
 
 
 cpdef str pystr_hasher_tcode_2(str value):
-    """Generate the hash digest of some metadata value
+    """Generate the hash digest of some str value
 
     Parameters
     ----------
     value : str
-        data to set as the value of the metadata key.
+        data value to hash
 
     Returns
     -------
     str
-        hex digest of the metadata value with typecode prepended by '{tcode}='.
+        hex digest of the data value with typecode prepended by '{tcode}='.
     """
     cdef bytes raw
     cdef str digest, res
@@ -130,4 +132,28 @@ cpdef str pystr_hasher_tcode_2(str value):
     raw = value.encode()
     digest = blake2b(raw, digest_size=20).hexdigest()
     res = f'2={digest}'
+    return res
+
+
+
+# --------------------------- bytes type data ----------------------------------------
+
+
+cpdef str pybytes_hasher_tcode_3(bytes value):
+    """Generate the hash digest of some bytes value
+
+    Parameters
+    ----------
+    value : bytes
+        data value to hash
+
+    Returns
+    -------
+    str
+        hex digest of the data value with typecode prepended by '{tcode}='.
+    """
+    cdef str digest, res
+
+    digest = blake2b(value, digest_size=20).hexdigest()
+    res = f'3={digest}'
     return res

--- a/src/hangar/remote/chunks.py
+++ b/src/hangar/remote/chunks.py
@@ -71,7 +71,7 @@ def clientCommitChunkedIterator(commit: str, parentVal: bytes, specVal: bytes,
 def tensorChunkedIterator(buf, uncomp_nbytes, pb2_request, *, err=None):
 
     compBytes = blosc.compress(
-        buf, clevel=3, cname='lz4', typesize=1, shuffle=blosc.NOSHUFFLE)
+        buf, clevel=3, cname='blosclz', shuffle=blosc.NOSHUFFLE)
 
     request = pb2_request(
         comp_nbytes=len(compBytes),

--- a/src/hangar/remote/chunks.py
+++ b/src/hangar/remote/chunks.py
@@ -139,7 +139,7 @@ def _serialize_arr(arr: np.ndarray) -> bytes:
 
 def _deserialize_arr(raw: bytes) -> np.ndarray:
     dtnum, ndim = struct.unpack('<bb', raw[0:2])
-    end = 2 + struct.calcsize(f'<{ndim}i')
+    end = 2 + (4 * ndim)
     arrshape = struct.unpack(f'<{ndim}i', raw[2:end])
     arr = np.frombuffer(raw, dtype=np.typeDict[dtnum], offset=end).reshape(arrshape)
     return arr

--- a/src/hangar/remote/client.py
+++ b/src/hangar/remote/client.py
@@ -295,8 +295,9 @@ class HangarClient(object):
         response = self.stub.PushSchema(request)
         return response
 
-    def fetch_data(self, schema_hash: str,
-                   digests: Sequence[str]) -> Sequence[Tuple[str, np.ndarray]]:
+    def fetch_data(
+            self, schema_hash: str, digests: Sequence[str]
+    ) -> Sequence[Tuple[str, np.ndarray]]:
         """Fetch data hash digests for a particular schema.
 
         As the total size of the data to be transferred isn't known before this
@@ -329,6 +330,7 @@ class HangarClient(object):
                                                  pb2_request=hangar_service_pb2.FetchDataRequest)
 
             replies = self.stub.FetchData(cIter)
+
             for idx, reply in enumerate(replies):
                 if idx == 0:
                     uncomp_nbytes, comp_nbytes = reply.uncomp_nbytes, reply.comp_nbytes
@@ -353,7 +355,7 @@ class HangarClient(object):
             data = chunks.deserialize_record(record)
             expected_hasher_tcode = hash_type_code_from_digest(data.digest)
             hash_func = hash_func_from_tcode(expected_hasher_tcode)
-            received_hash = hash_func(record.data)
+            received_hash = hash_func(data.data)
             if received_hash != data.digest:
                 raise RuntimeError(f'MANGLED! got: {received_hash} != requested: {data.digest}')
             received_data.append((received_hash, data.data))

--- a/src/hangar/remote/hangar_service.proto
+++ b/src/hangar/remote/hangar_service.proto
@@ -77,6 +77,12 @@ message SchemaRecord {
 }
 
 
+message NdArray {
+    // shape of the array
+
+}
+
+
 /*
 -------------------------------------------------------------------------------
 | Client Config from Server

--- a/src/hangar/remote/server.py
+++ b/src/hangar/remote/server.py
@@ -7,6 +7,7 @@ from concurrent import futures
 from os.path import join as pjoin
 import shutil
 import configparser
+from pprint import pprint as pp
 
 import blosc
 import grpc
@@ -26,10 +27,30 @@ from ..records import (
     hash_schema_db_key_from_raw_key,
     hash_data_db_key_from_raw_key,
 )
-from ..records.hashmachine import ndarray_hasher_tcode_0
+from ..records.hashmachine import hash_type_code_from_digest, hash_func_from_tcode
 from ..utils import set_blosc_nthreads
 
 set_blosc_nthreads()
+
+
+def server_config(server_dir, *, create: bool = True) -> configparser.ConfigParser:
+    CFG = configparser.ConfigParser()
+    dst_dir = Path(server_dir)
+    dst_path = dst_dir.joinpath(c.CONFIG_SERVER_NAME)
+    if dst_path.is_file():
+        CFG.read(dst_path)
+        print(f'Found Config File at {dst_path}')
+    else:
+        if create:
+            dst_dir.mkdir(exist_ok=True)
+            print(f'Creating Server Config File in {dst_path}')
+            src_path = Path(os.path.dirname(__file__), c.CONFIG_SERVER_NAME)
+            shutil.copyfile(src_path, dst_path)
+            CFG.read(src_path)
+        else:
+            src_path = Path(os.path.dirname(__file__), c.CONFIG_SERVER_NAME)
+            CFG.read(src_path)
+    return CFG
 
 
 class HangarServer(hangar_service_pb2_grpc.HangarServiceServicer):
@@ -61,13 +82,9 @@ class HangarServer(hangar_service_pb2_grpc.HangarServiceServicer):
                     schema_dtype=None)
                 self._rFs[backend].open(mode='r')
 
-        src_path = pjoin(os.path.dirname(__file__), c.CONFIG_SERVER_NAME)
-        dst_path = pjoin(repo_path, c.CONFIG_SERVER_NAME)
-        if not os.path.isfile(dst_path):
-            shutil.copyfile(src_path, dst_path)
-        self.CFG = configparser.ConfigParser()
-        self.CFG.read(dst_path)
-
+        self.CFG = server_config(repo_path, create=True)
+        print(f'Server Started with Config:')
+        pp({k: dict(v) for k, v in self.CFG.items()})
         self.txnregister = TxnRegister()
         self.repo_path = self.env.repo_path
         self.data_dir = pjoin(self.repo_path, c.DIR_DATA)
@@ -315,17 +332,16 @@ class HangarServer(hangar_service_pb2_grpc.HangarServiceServicer):
                     raise StopIteration()
                 else:
                     spec = backend_decoder(hashVal)
-                    tensor = self._rFs[spec.backend].read_data(spec)
+                    data = self._rFs[spec.backend].read_data(spec)
 
-                record = chunks.serialize_record(tensor, digest, '')
+                record = chunks.serialize_record(data, digest, '')
                 records.append(record)
                 totalSize += len(record)
                 if totalSize >= fetch_max_nbytes:
                     pack = chunks.serialize_record_pack(records)
                     err = hangar_service_pb2.ErrorProto(code=0, message='OK')
-                    cIter = chunks.tensorChunkedIterator(
-                        buf=pack, uncomp_nbytes=len(pack), itemsize=tensor.itemsize,
-                        pb2_request=hangar_service_pb2.FetchDataReply, err=err)
+                    cIter = chunks.tensorChunkedIterator(buf=pack, uncomp_nbytes=len(pack),
+                                                         pb2_request=hangar_service_pb2.FetchDataReply, err=err)
                     yield from cIter
                     msg = 'HANGAR REQUESTED RETRY: developer enforced limit on returned '\
                           'raw data size to prevent memory overload of user system.'
@@ -342,9 +358,8 @@ class HangarServer(hangar_service_pb2_grpc.HangarServiceServicer):
             if totalSize > 0:
                 pack = chunks.serialize_record_pack(records)
                 err = hangar_service_pb2.ErrorProto(code=0, message='OK')
-                cIter = chunks.tensorChunkedIterator(
-                    buf=pack, uncomp_nbytes=len(pack), itemsize=tensor.itemsize,
-                    pb2_request=hangar_service_pb2.FetchDataReply, err=err)
+                cIter = chunks.tensorChunkedIterator(buf=pack, uncomp_nbytes=len(pack),
+                                                     pb2_request=hangar_service_pb2.FetchDataReply, err=err)
                 yield from cIter
             self.txnregister.abort_reader_txn(self.env.hashenv)
 
@@ -379,7 +394,9 @@ class HangarServer(hangar_service_pb2_grpc.HangarServiceServicer):
         for record in unpacked_records:
             data = chunks.deserialize_record(record)
             schema_hash = data.schema
-            received_hash = ndarray_hasher_tcode_0(data.array)
+            expected_hasher_tcode = hash_type_code_from_digest(data.digest)
+            hash_func = hash_func_from_tcode(expected_hasher_tcode)
+            received_hash = hash_func(data.data)
             if received_hash != data.digest:
                 msg = f'HASH MANGLED, received: {received_hash} != expected digest: {data.digest}'
                 context.set_details(msg)
@@ -387,7 +404,7 @@ class HangarServer(hangar_service_pb2_grpc.HangarServiceServicer):
                 err = hangar_service_pb2.ErrorProto(code=15, message=msg)
                 reply = hangar_service_pb2.PushDataReply(error=err)
                 return reply
-            received_data.append((received_hash, data.array))
+            received_data.append((received_hash, data.data))
         _ = self.CW.data(schema_hash, received_data)  # returns saved)_digests
         err = hangar_service_pb2.ErrorProto(code=0, message='OK')
         reply = hangar_service_pb2.PushDataReply(error=err)
@@ -497,7 +514,6 @@ class HangarServer(hangar_service_pb2_grpc.HangarServiceServicer):
         uncompBytes = blosc.decompress(hBytes)
         c_hashs_raw = chunks.deserialize_record_pack(uncompBytes)
         c_hashset = set([chunks.deserialize_ident(raw).digest for raw in c_hashs_raw])
-
         s_hashset = set(hashs.HashQuery(self.env.hashenv).list_all_hash_keys_raw())
         s_missing = c_hashset.difference(s_hashset)
         s_hashs_raw = [chunks.serialize_ident(s_mis, '') for s_mis in s_missing]
@@ -556,14 +572,8 @@ def serve(hangar_path: str,
 
     # ------------------- Configure Server ------------------------------------
 
-    dst_path = pjoin(hangar_path, c.DIR_HANGAR_SERVER, c.CONFIG_SERVER_NAME)
-    CFG = configparser.ConfigParser()
-    if os.path.isfile(dst_path):
-        CFG.read(dst_path)
-    else:
-        src_path = pjoin(os.path.dirname(__file__), c.CONFIG_SERVER_NAME)
-        CFG.read(src_path)
-
+    server_dir = pjoin(hangar_path, c.DIR_HANGAR_SERVER)
+    CFG = server_config(server_dir, create=False)
     serverCFG = CFG['SERVER_GRPC']
     enable_compression = serverCFG['enable_compression']
     if enable_compression == 'NoCompression':
@@ -609,7 +619,6 @@ def serve(hangar_path: str,
 
     # ------------------- Start the GRPC server -------------------------------
 
-    server_dir = pjoin(hangar_path, c.DIR_HANGAR_SERVER)
     hangserv = HangarServer(server_dir, overwrite)
     hangar_service_pb2_grpc.add_HangarServiceServicer_to_server(hangserv, server)
     port = server.add_insecure_port(channel_address)

--- a/src/hangar/remotes.py
+++ b/src/hangar/remotes.py
@@ -364,14 +364,22 @@ class Remotes(object):
                             while notEmpty:
                                 notEmpty = curs.delete()
                     unpack_commit_ref(self._env.refenv, tmpDB, commit)
+                    print(f'Client processing commit {commit}')
+                    recQuery = queries.RecordQuery(tmpDB)
+
                     # handle column_names option
+                    cmt_column_names = recQuery.column_names()
                     if column_names is None:
-                        column_names = queries.RecordQuery(tmpDB).column_names()
-                    for asetn in column_names:
-                        cmtData_hashs = queries.RecordQuery(tmpDB).column_data_hashes(asetn)
+                        cmt_columns = cmt_column_names
+                    else:
+                        cmt_columns = [col for col in column_names if col in cmt_column_names]
+                    for col in cmt_columns:
+                        print(f'Client Querying Hashs for Column: {col}')
+                        cmtData_hashs = recQuery.column_data_hashes(col)
                         allHashs.update(cmtData_hashs)
             finally:
                 tmpDB.close()
+
         hashTxn = TxnRegister().begin_reader_txn(self._env.hashenv)
         try:
             m_schema_hash_map = defaultdict(list)

--- a/src/hangar/typesystem/__init__.py
+++ b/src/hangar/typesystem/__init__.py
@@ -3,8 +3,10 @@ from .descriptors import (
 )
 from .ndarray import NdarrayVariableShape, NdarrayFixedShape
 from .pystring import StringVariableShape
+from .pybytes import BytesVariableShape
 
 __all__ = [
     'Descriptor', 'OneOf', 'DictItems', 'EmptyDict', 'SizedIntegerTuple',
-    'checkedmeta', 'NdarrayVariableShape', 'NdarrayFixedShape', 'StringVariableShape',
+    'checkedmeta', 'NdarrayVariableShape', 'NdarrayFixedShape',
+    'StringVariableShape', 'BytesVariableShape'
 ]

--- a/src/hangar/typesystem/base.py
+++ b/src/hangar/typesystem/base.py
@@ -7,7 +7,7 @@ class ColumnLayout(String):
     pass
 
 
-@OneOf(['str', 'ndarray'])
+@OneOf(['str', 'ndarray', 'bytes'])
 class ColumnDType(String):
     pass
 

--- a/src/hangar/typesystem/pybytes.py
+++ b/src/hangar/typesystem/pybytes.py
@@ -49,7 +49,7 @@ class BytesSchemaBase(ColumnBase):
             raise ValueError(
                 '`backend_options` cannot be set if `backend` is not also provided.')
 
-        if not isinstance(dtype, bytes):
+        if not isinstance(dtype, str):
             dtype = repr(dtype).replace(' ', '')
 
         self._dtype = dtype

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,6 @@
 import time
 import shutil
 import random
-from random import randint
-import platform
 from os.path import join as pjoin
 from os import mkdir
 
@@ -11,7 +9,6 @@ import numpy as np
 
 from hangar import Repository
 from hangar.checkout import WriterCheckout
-
 import hangar
 
 
@@ -27,6 +24,7 @@ def classrepo(tmp_path_factory) -> Repository:
     old01_size = hangar.backends.hdf5_01.COLLECTION_SIZE
     old10_size = hangar.backends.numpy_10.COLLECTION_SIZE
     old30_lmdb_settings = hangar.backends.lmdb_30.LMDB_SETTINGS
+    old31_lmdb_settings = hangar.backends.lmdb_31.LMDB_SETTINGS
     hangar.backends.hdf5_00.COLLECTION_COUNT = 5
     hangar.backends.hdf5_00.COLLECTION_SIZE = 20
     hangar.backends.hdf5_01.COLLECTION_COUNT = 5
@@ -34,7 +32,6 @@ def classrepo(tmp_path_factory) -> Repository:
     hangar.backends.numpy_10.COLLECTION_SIZE = 50
     hangar.backends.lmdb_30.LMDB_SETTINGS['map_size'] = 1_000_000
     hangar.backends.lmdb_31.LMDB_SETTINGS['map_size'] = 1_000_000
-
 
     old_map_size = hangar.constants.LMDB_SETTINGS['map_size']
     hangar.constants.LMDB_SETTINGS['map_size'] = 2_000_000
@@ -51,6 +48,7 @@ def classrepo(tmp_path_factory) -> Repository:
     hangar.backends.hdf5_01.COLLECTION_SIZE = old01_size
     hangar.backends.numpy_10.COLLECTION_SIZE = old10_size
     hangar.backends.lmdb_30.LMDB_SETTINGS = old30_lmdb_settings
+    hangar.backends.lmdb_31.LMDB_SETTINGS = old31_lmdb_settings
     repo_obj._env._close_environments()
 
 
@@ -225,26 +223,46 @@ def repo_2_br_no_conf(repo_1_br_no_conf) -> Repository:
     return repo
 
 
+def mock_server_config(*args, **kwargs):
+    import os
+    import configparser
+    from pathlib import Path
+    from hangar import constants as c
+    from hangar import remote
+
+    src_path = Path(os.path.dirname(remote.__file__), c.CONFIG_SERVER_NAME)
+    CFG = configparser.ConfigParser()
+    CFG.read(src_path)
+    CFG['SERVER_GRPC']['max_concurrent_rpcs'] = '10'
+    CFG['SERVER_GRPC']['max_thread_pool_workers'] = '2'
+    return CFG
+
+
+def mock_nbytes_limit_cfg(*args, **kwargs):
+    CFG = mock_server_config()
+    CFG['SERVER_GRPC']['fetch_max_nbytes'] = '500000'
+    CFG['CLIENT_GRPC']['push_max_nbytes'] = '500000'
+    return CFG
+
+
 @pytest.fixture()
-def server_instance(managed_tmpdir, worker_id, monkeypatch):
+def server_instance(monkeypatch, managed_tmpdir, worker_id):
     from secrets import choice
-    from hangar.remote.server import serve
+    from hangar.remote import server
+    monkeypatch.setattr(server, 'server_config', mock_server_config)
 
     possibble_addresses = [x for x in range(50000, 59999)]
     chosen_address = choice(possibble_addresses)
     address = f'localhost:{chosen_address}'
     base_tmpdir = pjoin(managed_tmpdir, f'{worker_id[-1]}')
     mkdir(base_tmpdir)
-
-    server, hangserver, _ = serve(base_tmpdir, overwrite=True, channel_address=address)
-    monkeypatch.setitem(hangserver.CFG['SERVER_GRPC'], 'max_concurrent_rpcs', '20')
-    monkeypatch.setitem(hangserver.CFG['SERVER_GRPC'], 'max_thread_pool_workers', '5')
+    server, hangserver, _ = server.serve(base_tmpdir, overwrite=True, channel_address=address)
     server.start()
     yield address
 
     hangserver.close()
     server.stop(0.1)
-    server.wait_for_termination(timeout=10)
+    server.wait_for_termination(timeout=2)
 
 
 @pytest.fixture()
@@ -254,3 +272,51 @@ def written_two_cmt_server_repo(server_instance, two_commit_filled_samples_repo)
     success = two_commit_filled_samples_repo.remote.push('origin', 'master')
     assert success == 'master'
     yield (server_instance, two_commit_filled_samples_repo)
+
+
+@pytest.fixture()
+def server_instance_nbytes_limit(monkeypatch, managed_tmpdir, worker_id):
+    from hangar.remote import server
+    from secrets import choice
+    monkeypatch.setattr(server, 'server_config', mock_nbytes_limit_cfg)
+
+    possibble_addresses = [x for x in range(50000, 59999)]
+    chosen_address = choice(possibble_addresses)
+    address = f'localhost:{chosen_address}'
+    base_tmpdir = pjoin(managed_tmpdir, f'{worker_id[-1]}')
+    mkdir(base_tmpdir)
+    server, hangserver, _ = server.serve(base_tmpdir, overwrite=True, channel_address=address)
+    server.start()
+    yield address
+
+    hangserver.env._close_environments()
+    hangserver.close()
+    server.stop(0.1)
+    server.wait_for_termination(timeout=2)
+
+
+@pytest.fixture()
+def server_instance_push_restricted(monkeypatch, managed_tmpdir, worker_id):
+    from hangar.remote import server
+    from secrets import choice
+    monkeypatch.setattr(server, 'server_config', mock_server_config)
+
+    possibble_addresses = [x for x in range(50000, 59999)]
+    chosen_address = choice(possibble_addresses)
+    address = f'localhost:{chosen_address}'
+    base_tmpdir = pjoin(managed_tmpdir, f'{worker_id[-1]}')
+    mkdir(base_tmpdir)
+    server, hangserver, _ = server.serve(base_tmpdir,
+                                         overwrite=True,
+                                         channel_address=address,
+                                         restrict_push=True,
+                                         username='right_username',
+                                         password='right_password')
+    server.start()
+    yield address
+
+    hangserver.env._close_environments()
+    hangserver.close()
+    server.stop(0.1)
+    server.wait_for_termination(timeout=2)
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,8 @@ def classrepo(tmp_path_factory) -> Repository:
     hangar.backends.hdf5_01.COLLECTION_SIZE = 20
     hangar.backends.numpy_10.COLLECTION_SIZE = 50
     hangar.backends.lmdb_30.LMDB_SETTINGS['map_size'] = 1_000_000
+    hangar.backends.lmdb_31.LMDB_SETTINGS['map_size'] = 1_000_000
+
 
     old_map_size = hangar.constants.LMDB_SETTINGS['map_size']
     hangar.constants.LMDB_SETTINGS['map_size'] = 2_000_000
@@ -56,12 +58,12 @@ def classrepo(tmp_path_factory) -> Repository:
 def managed_tmpdir(monkeypatch, tmp_path):
     monkeypatch.setitem(hangar.constants.LMDB_SETTINGS, 'map_size', 2_000_000)
     monkeypatch.setitem(hangar.backends.lmdb_30.LMDB_SETTINGS, 'map_size', 1_000_000)
+    monkeypatch.setitem(hangar.backends.lmdb_31.LMDB_SETTINGS, 'map_size', 1_000_000)
     monkeypatch.setattr(hangar.backends.hdf5_00, 'COLLECTION_COUNT', 5)
     monkeypatch.setattr(hangar.backends.hdf5_00, 'COLLECTION_SIZE', 20)
     monkeypatch.setattr(hangar.backends.hdf5_01, 'COLLECTION_COUNT', 5)
     monkeypatch.setattr(hangar.backends.hdf5_01, 'COLLECTION_SIZE', 20)
     monkeypatch.setattr(hangar.backends.numpy_10, 'COLLECTION_SIZE', 50)
-    monkeypatch.setitem(hangar.backends.lmdb_30.LMDB_SETTINGS, 'map_size', 1_000_000)
     hangar.txnctx.TxnRegisterSingleton._instances = {}
     yield tmp_path
     shutil.rmtree(tmp_path)

--- a/tests/property_based/conftest.py
+++ b/tests/property_based/conftest.py
@@ -3,3 +3,4 @@ import pytest
 variable_shape_backend_params = ['00', '10']
 fixed_shape_backend_params = ['00', '01', '10']
 str_variable_shape_backend_params = ['30']
+bytes_variable_shape_backend_params = ['31']

--- a/tests/test_column_definition_permutations.py
+++ b/tests/test_column_definition_permutations.py
@@ -184,6 +184,87 @@ def column_permutations_write_checkout(column_permutation_repo):
     co.close()
 
 
+@pytest.mark.parametrize('column_type,column_kwargs', [
+    ('ndarray', {'prototype': np.array([1, 2, 3])}),
+    ('str', {}),
+    ('bytes', {}),
+])
+@pytest.mark.parametrize('contains_subsamples', [True, False])
+def test_cannot_create_column_within_cm(repo, column_type, column_kwargs, contains_subsamples):
+    co = repo.checkout(write=True)
+    with co:
+        with pytest.raises(PermissionError):
+            if column_type == 'ndarray':
+                co.add_ndarray_column(
+                    'testcol', contains_subsamples=contains_subsamples, **column_kwargs)
+            elif column_type == 'str':
+                co.add_str_column(
+                    'testcol', contains_subsamples=contains_subsamples, **column_kwargs)
+            elif column_type == 'bytes':
+                co.add_bytes_column(
+                    'testcol', contains_subsamples=contains_subsamples, **column_kwargs)
+            else:
+                raise ValueError(column_type)
+    co.close()
+
+
+@pytest.mark.parametrize('column_type,column_kwargs', [
+    ('ndarray', {'prototype': np.array([1, 2, 3])}),
+    ('str', {}),
+    ('bytes', {}),
+])
+def test_contains_subsamples_non_bool_value_fails(repo, column_type, column_kwargs):
+    co = repo.checkout(write=True)
+    with pytest.raises(ValueError):
+        if column_type == 'ndarray':
+            co.add_ndarray_column(
+                'testcol', contains_subsamples=None, **column_kwargs)
+        elif column_type == 'str':
+            co.add_str_column(
+                'testcol', contains_subsamples=None, **column_kwargs)
+        elif column_type == 'bytes':
+            co.add_bytes_column(
+                'testcol', contains_subsamples=None, **column_kwargs)
+        else:
+            raise ValueError(column_type)
+    co.close()
+
+
+@pytest.mark.parametrize('column_type,column_kwargs', [
+    ('ndarray', {'prototype': np.array([1, 2, 3])}),
+    ('str', {}),
+    ('bytes', {}),
+])
+@pytest.mark.parametrize('contains_subsamples', [True, False])
+def test_cannot_create_column_name_exists(repo, column_type, column_kwargs, contains_subsamples):
+    co = repo.checkout(write=True)
+
+    # setup so that a column already exists
+    if column_type == 'ndarray':
+        co.add_ndarray_column(
+            'testcol', contains_subsamples=contains_subsamples, **column_kwargs)
+    elif column_type == 'str':
+        co.add_str_column(
+            'testcol', contains_subsamples=contains_subsamples, **column_kwargs)
+    elif column_type == 'bytes':
+        co.add_bytes_column(
+            'testcol', contains_subsamples=contains_subsamples, **column_kwargs)
+
+    with pytest.raises(LookupError):
+        if column_type == 'ndarray':
+            co.add_ndarray_column(
+                'testcol', contains_subsamples=contains_subsamples, **column_kwargs)
+        elif column_type == 'str':
+            co.add_str_column(
+                'testcol', contains_subsamples=contains_subsamples, **column_kwargs)
+        elif column_type == 'bytes':
+            co.add_bytes_column(
+                'testcol', contains_subsamples=contains_subsamples, **column_kwargs)
+        else:
+            raise ValueError(column_type)
+    co.close()
+
+
 def test_read_data_from_column_permutations(column_permutations_read_write_checkout):
     co, column_data, column_data_partials = column_permutations_read_write_checkout
 

--- a/tests/test_column_nested.py
+++ b/tests/test_column_nested.py
@@ -1,7 +1,7 @@
 """Tests for the class methods contained in the nested subsample column accessor.
 """
-import pytest
 import numpy as np
+import pytest
 from conftest import fixed_shape_backend_params, variable_shape_backend_params
 
 
@@ -68,7 +68,7 @@ class TestArraysetSetup:
 
         # init and immediate delete leaves no trace
         co.add_ndarray_column(name='writtenaset', shape=(5, 7), dtype=np.float64,
-                                 backend=aset_backend, contains_subsamples=True)
+                              backend=aset_backend, contains_subsamples=True)
         assert len(co.columns) == 1
         co.columns.delete('writtenaset')
         assert len(co.columns) == 0
@@ -79,7 +79,7 @@ class TestArraysetSetup:
         co = aset_subsamples_initialized_repo.checkout(write=True)
         assert len(co.columns) == 0
         co.add_ndarray_column(name='writtenaset', shape=(5, 7), dtype=np.float64,
-                                 backend=aset_backend, contains_subsamples=True)
+                              backend=aset_backend, contains_subsamples=True)
         co.commit('this is a commit message')
         co.close()
         co = aset_subsamples_initialized_repo.checkout(write=True)
@@ -95,15 +95,15 @@ class TestArraysetSetup:
     def test_init_same_arrayset_twice_fails_again(self, aset_backend, repo, randomsizedarray):
         co = repo.checkout(write=True)
         co.add_ndarray_column('aset', prototype=randomsizedarray,
-                                 backend=aset_backend, contains_subsamples=True)
+                              backend=aset_backend, contains_subsamples=True)
         with pytest.raises(LookupError):
             # test if everything is the same as initalized one.
             co.add_ndarray_column('aset', prototype=randomsizedarray,
-                                     backend=aset_backend, contains_subsamples=True)
+                                  backend=aset_backend, contains_subsamples=True)
         with pytest.raises(LookupError):
             # test if column container type is different than existing name (no subsamples0
             co.add_ndarray_column('aset', prototype=randomsizedarray,
-                                     backend=aset_backend, contains_subsamples=False)
+                                  backend=aset_backend, contains_subsamples=False)
         co.close()
 
     @pytest.mark.parametrize("aset_backend", fixed_shape_backend_params)
@@ -114,18 +114,18 @@ class TestArraysetSetup:
         with pytest.raises(ValueError):
             # cannot have zero valued size for any dimension
             co.add_ndarray_column('aset', shape=shape, dtype=np.int,
-                                     backend=aset_backend, contains_subsamples=True)
+                                  backend=aset_backend, contains_subsamples=True)
 
         shape = [1] * 31
         aset = co.add_ndarray_column('aset1', shape=shape, dtype=np.int,
-                                        backend=aset_backend, contains_subsamples=True)
+                                     backend=aset_backend, contains_subsamples=True)
         assert len(aset.shape) == 31
 
         shape = [1] * 32
         with pytest.raises(ValueError):
             # maximum tensor rank must be <= 31
             co.add_ndarray_column('aset2', shape=shape, dtype=np.int,
-                                     backend=aset_backend, contains_subsamples=True)
+                                  backend=aset_backend, contains_subsamples=True)
         co.close()
 
 
@@ -223,7 +223,7 @@ def subsample_writer_written_aset(backend_params, repo, monkeypatch):
 
     co = repo.checkout(write=True)
     aset = co.add_ndarray_column('foo', shape=(4, 4), dtype=np.uint8, variable_shape=False,
-                                    backend=backend_params, contains_subsamples=True)
+                                 backend=backend_params, contains_subsamples=True)
     yield aset
     co.close()
 
@@ -256,7 +256,7 @@ class TestAddData:
             assert f'subsample{subsample_idx}' in aset._samples['baz']._subsamples
 
     def test_update_sample_kwargs_and_other_dict_doesnt_modify_input_in_calling_scope(
-        self, subsample_writer_written_aset, iterable_subsamples, iterable_samples
+            self, subsample_writer_written_aset, iterable_subsamples, iterable_samples
     ):
         """ensure bug does not revert.
 
@@ -277,7 +277,9 @@ class TestAddData:
         #
         assert list(iterable_samples.items()) == iterable_samples_before
 
-    def test_update_sample_kwargs_and_iterably_empty_arrayset(self, subsample_writer_written_aset, iterable_subsamples, iterable_samples):
+    def test_update_sample_kwargs_and_iterably_empty_arrayset(
+            self, subsample_writer_written_aset, iterable_subsamples, iterable_samples
+    ):
         aset = subsample_writer_written_aset
         aset.update(iterable_samples, fookwarg=iterable_subsamples)
         assert len(aset._samples) == len(iterable_samples) + 1
@@ -286,7 +288,9 @@ class TestAddData:
         for sample_idx in range(len(iterable_samples)):
             assert f'sample{sample_idx}' in aset._samples
 
-    def test_update_sample_subsamples_duplicate_data_does_not_save_new(self, subsample_writer_written_aset, iterable_samples):
+    def test_update_sample_subsamples_duplicate_data_does_not_save_new(
+            self, subsample_writer_written_aset, iterable_samples
+    ):
         aset = subsample_writer_written_aset
         aset.update(iterable_samples)
         old_specs = {}
@@ -347,7 +351,8 @@ class TestAddData:
                 assert f'subsample{subsample_idx}' in aset._samples[
                     f'sample{sample_idx}']._subsamples
 
-    def test_update_subsamples_empty_arrayset(self, multi_item_generator, subsample_writer_written_aset, iterable_subsamples):
+    def test_update_subsamples_empty_arrayset(self, multi_item_generator, subsample_writer_written_aset,
+                                              iterable_subsamples):
         aset = subsample_writer_written_aset
         for sample_idx in range(multi_item_generator):
             aset[f'sample{sample_idx}'] = {'foo': np.arange(16, dtype=np.uint8).reshape(4, 4) + 10}
@@ -375,7 +380,7 @@ class TestAddData:
             assert 'bar' in aset._samples[f'sample{sample_idx}']._subsamples
 
     def test_update_subsamples_kwargs_and_other_dict_doesnt_modify_input_in_calling_scopy(
-        self, multi_item_generator, subsample_writer_written_aset, iterable_subsamples
+            self, multi_item_generator, subsample_writer_written_aset, iterable_subsamples
     ):
         """ensure bug does not revert.
 
@@ -390,7 +395,8 @@ class TestAddData:
 
         for sample_idx in range(multi_item_generator):
             aset[f'sample{sample_idx}'] = {'foo': np.arange(16, dtype=np.uint8).reshape(4, 4) + 10}
-            aset[f'sample{sample_idx}'].update(iterable_subsamples, kwargadded=np.arange(16, dtype=np.uint8).reshape(4, 4))
+            aset[f'sample{sample_idx}'].update(iterable_subsamples,
+                                               kwargadded=np.arange(16, dtype=np.uint8).reshape(4, 4))
             # in bug case, would now observe that iterable_subsamples would have been
             # silently modified in a method analogous to calling:
             #
@@ -400,7 +406,7 @@ class TestAddData:
         assert list(iterable_subsamples.keys()) == iterable_subsamples_before
 
     def test_update_subsamples_via_kwargs_and_iterable_empty_arrayset(
-        self, multi_item_generator, subsample_writer_written_aset, iterable_subsamples
+            self, multi_item_generator, subsample_writer_written_aset, iterable_subsamples
     ):
         aset = subsample_writer_written_aset
         for sample_idx in range(multi_item_generator):
@@ -416,11 +422,12 @@ class TestAddData:
             assert 'bar' in aset._samples[f'sample{sample_idx}']._subsamples
 
     @pytest.mark.parametrize('backend', fixed_shape_backend_params)
-    def test_update_subsamples_context_manager(self, backend, multi_item_generator,
-                                               iterable_subsamples, repo):
+    def test_update_subsamples_context_manager(
+            self, backend, multi_item_generator, iterable_subsamples, repo
+    ):
         co = repo.checkout(write=True)
         aset = co.add_ndarray_column('foo', shape=(4, 4), dtype=np.uint8,
-                                        backend=backend, contains_subsamples=True)
+                                     backend=backend, contains_subsamples=True)
 
         for sample_idx in range(multi_item_generator):
             aset[f'sample{sample_idx}'] = {'foo': np.arange(16, dtype=np.uint8).reshape(4, 4) + 10}
@@ -440,7 +447,9 @@ class TestAddData:
                 assert f'subsample{subsample_idx}' in aset._samples[f'sample{sample_idx}']._subsamples
         co.close()
 
-    def test_setitem_sample_empty_arrayset(self, multi_item_generator, iterable_subsamples, subsample_writer_written_aset):
+    def test_setitem_sample_empty_arrayset(
+            self, multi_item_generator, iterable_subsamples, subsample_writer_written_aset
+    ):
         aset = subsample_writer_written_aset
 
         subsamples_dict = dict(iterable_subsamples)
@@ -472,7 +481,8 @@ class TestAddData:
             aset['sample']['subsample'] = np.arange(16, dtype=np.uint8).reshape(4, 4)
         assert len(aset) == 0
 
-    def test_setitem_subsamples_contextmanager(self, multi_item_generator, iterable_subsamples, subsample_writer_written_aset):
+    def test_setitem_subsamples_contextmanager(self, multi_item_generator, iterable_subsamples,
+                                               subsample_writer_written_aset):
         aset = subsample_writer_written_aset
         subsamples_dict = dict(iterable_subsamples)
         for sample_idx in range(multi_item_generator):
@@ -530,7 +540,7 @@ class TestAddData:
     def test_update_noniterable_subsample_iter_fails(self, backend, other, repo):
         co = repo.checkout(write=True)
         aset = co.add_ndarray_column('foo', shape=(4, 4), dtype=np.uint8,
-                                        backend=backend, contains_subsamples=True)
+                                     backend=backend, contains_subsamples=True)
         aset[f'foo'] = {'foo': np.arange(16, dtype=np.uint8).reshape(4, 4) + 10}
         with pytest.raises(ValueError, match='dictionary update sequence'):
             aset['foo'].update(other)
@@ -544,7 +554,7 @@ class TestAddData:
     def test_update_subsamples_with_too_many_arguments_fails(self, backend, repo):
         co = repo.checkout(write=True)
         aset = co.add_ndarray_column('foo', shape=(4, 4), dtype=np.uint8,
-                                        backend=backend, contains_subsamples=True)
+                                     backend=backend, contains_subsamples=True)
         arr = np.arange(16, dtype=np.uint8).reshape(4, 4)
         aset[f'foo'] = {'foo': arr + 10}
         with pytest.raises(TypeError, match='takes from 1 to 2 positional arguments'):
@@ -558,7 +568,7 @@ class TestAddData:
     def test_update_subsamples_with_too_few_arguments_fails(self, backend, repo):
         co = repo.checkout(write=True)
         aset = co.add_ndarray_column('foo', shape=(4, 4), dtype=np.uint8,
-                                        backend=backend, contains_subsamples=True)
+                                     backend=backend, contains_subsamples=True)
         arr = np.arange(16, dtype=np.uint8).reshape(4, 4)
         aset[f'foo'] = {'foo': arr + 10}
         with pytest.raises(ValueError, match='dictionary update sequence element #0 has length 1; 2 is required'):
@@ -652,8 +662,8 @@ class TestAddData:
     def test_update_sample_invalid_array_fails_fixed_shape(self, backend, variable_shape, other, repo):
         co = repo.checkout(write=True)
         aset = co.add_ndarray_column('foo',
-                                        shape=(2, 2), dtype=np.uint8, variable_shape=variable_shape,
-                                        backend=backend, contains_subsamples=True)
+                                     shape=(2, 2), dtype=np.uint8, variable_shape=variable_shape,
+                                     backend=backend, contains_subsamples=True)
         with pytest.raises(ValueError):
             aset.update(other)
         assert len(aset._samples) == 0
@@ -691,8 +701,8 @@ class TestAddData:
     def test_update_subsample_invalid_array_fails_fixed_shape(self, backend, variable_shape, other, repo):
         co = repo.checkout(write=True)
         aset = co.add_ndarray_column('foo',
-                                        shape=(4, 4), dtype=np.uint8, variable_shape=variable_shape,
-                                        backend=backend, contains_subsamples=True)
+                                     shape=(4, 4), dtype=np.uint8, variable_shape=variable_shape,
+                                     backend=backend, contains_subsamples=True)
         aset['sample'] = {0: np.zeros((4, 4), dtype=np.uint8)}
         with pytest.raises(ValueError):
             aset['sample'].update(other)
@@ -707,7 +717,7 @@ class TestAddData:
 
 @pytest.fixture(scope='class')
 def subsample_data_map():
-    arr = np.arange(5*7).astype(np.uint16).reshape((5, 7))
+    arr = np.arange(5 * 7).astype(np.uint16).reshape((5, 7))
     res = {
         'foo': {
             0: arr,
@@ -736,8 +746,8 @@ def write_enabled(request):
 def initialized_arrayset(write_enabled, backend_param, classrepo, subsample_data_map):
     co = classrepo.checkout(write=True)
     aset = co.add_ndarray_column(f'foo{backend_param}{int(write_enabled)}',
-                                    shape=(5, 7), dtype=np.uint16, backend=backend_param,
-                                    contains_subsamples=True)
+                                 shape=(5, 7), dtype=np.uint16, backend=backend_param,
+                                 contains_subsamples=True)
     aset.update(subsample_data_map)
     co.commit(f'done {backend_param}{write_enabled}')
     co.close()
@@ -755,7 +765,7 @@ def initialized_arrayset(write_enabled, backend_param, classrepo, subsample_data
 def initialized_arrayset_write_only(backend_param, repo, subsample_data_map):
     co = repo.checkout(write=True)
     aset = co.add_ndarray_column('foo', shape=(5, 7), dtype=np.uint16,
-                                    backend=backend_param, contains_subsamples=True)
+                                 backend=backend_param, contains_subsamples=True)
     aset.update(subsample_data_map)
     yield co.columns['foo']
     co.close()
@@ -891,7 +901,9 @@ class TestContainerIntrospection:
             for k, v in res.items():
                 assert_equal(v, subsample_data[k])
 
-    def test_get_sample_test_subsample_contains_remote_references_property(self, initialized_arrayset, subsample_data_map):
+    def test_get_sample_test_subsample_contains_remote_references_property(
+            self, initialized_arrayset, subsample_data_map
+    ):
         aset = initialized_arrayset
         # test works before add remote references
         aset.contains_remote_references is False
@@ -968,6 +980,7 @@ class TestContainerIntrospection:
             hasattr(sample, '_mode')
         setattr(aset, '_mode', original)
         setattr(sample, '_mode', original)
+
 
 # ------------------------------ Getting Data --------------------------------------------
 
@@ -1453,11 +1466,11 @@ class TestGetDataMethods:
     ):
         co = repo.checkout(write=True)
         aset1 = co.add_ndarray_column('aset1', prototype=randomsizedarray,
-                                         backend=aset1_backend, contains_subsamples=True)
+                                      backend=aset1_backend, contains_subsamples=True)
         aset2 = co.add_ndarray_column('aset2', shape=(2, 2), dtype=np.int,
-                                         backend=aset2_backend, contains_subsamples=True)
+                                      backend=aset2_backend, contains_subsamples=True)
         aset3 = co.add_ndarray_column('aset3', shape=(3, 4), dtype=np.float32,
-                                         backend=aset3_backend, contains_subsamples=True)
+                                      backend=aset3_backend, contains_subsamples=True)
         with aset1 as d1, aset2 as d2, aset3 as d3:
             d1[1] = {11: randomsizedarray}
             d2[1] = {21: np.ones((2, 2), dtype=np.int)}
@@ -1475,11 +1488,11 @@ class TestGetDataMethods:
     ):
         co = repo.checkout(write=True)
         aset1 = co.add_ndarray_column('aset1', prototype=randomsizedarray,
-                                         backend=aset1_backend, contains_subsamples=True)
+                                      backend=aset1_backend, contains_subsamples=True)
         aset2 = co.add_ndarray_column('aset2', shape=(2, 2), dtype=np.int,
-                                         backend=aset2_backend, contains_subsamples=True)
+                                      backend=aset2_backend, contains_subsamples=True)
         aset3 = co.add_ndarray_column('aset3', shape=(3, 4), dtype=np.float32,
-                                         backend=aset3_backend, contains_subsamples=True)
+                                      backend=aset3_backend, contains_subsamples=True)
         with aset1 as d1, aset2 as d2, aset3 as d3:
             d1[1] = {11: randomsizedarray}
             d2[1] = {21: np.ones((2, 2), dtype=np.int)}
@@ -1508,7 +1521,7 @@ class TestWriteThenReadCheckout:
     def test_add_data_commit_checkout_read_only_contains_same(self, backend, repo, subsample_data_map):
         co = repo.checkout(write=True)
         aset = co.add_ndarray_column('foo', shape=(5, 7), dtype=np.uint16,
-                                        backend=backend, contains_subsamples=True)
+                                     backend=backend, contains_subsamples=True)
         added = aset.update(subsample_data_map)
         for sample_name, subsample_data in subsample_data_map.items():
             sample = aset.get(sample_name)

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -2,12 +2,6 @@ import pytest
 import numpy as np
 
 
-def create_meta_nt(name):
-    from hangar.records import MetadataRecordKey
-    res = MetadataRecordKey(name)
-    return res
-
-
 class TestReaderWriterDiff(object):
 
     @pytest.mark.parametrize('writer', [False, True])

--- a/tests/test_remote_serialize.py
+++ b/tests/test_remote_serialize.py
@@ -9,7 +9,7 @@ param_digest = ['0=digesta', '0=digestaaaaaa', '2=digestaaaaaaaaaaaaaaaaaaaaaaaa
 param_schema = ['schemaa', 'schemaaaaaaaaa', 'schemaaaaaaaaaaaaaaaa']
 
 
-def assert_equal(arr, arr2):
+def assert_array_equal(arr, arr2):
     assert np.array_equal(arr, arr2)
     assert arr.dtype == arr2.dtype
 
@@ -37,6 +37,23 @@ def array_testcase(arr_shape, arr_dtype):
     return arr.astype(arr_dtype)
 
 
+@pytest.fixture(scope='module', params=[
+    'hello', ' world', 'how are you today! ',
+    '325', f'{"".join([str(i) for i in range(100)])}',
+    'o\n\x01'
+])
+def str_testcase(request):
+    return request.param
+
+
+@pytest.fixture(scope='module', params=[
+    b'hello', b' world', b'how are you today! ',
+    b'325', b'\x01\x00\x12\x14'
+])
+def bytes_testcase(request):
+    return request.param
+
+
 @pytest.fixture(scope='module')
 def ident_testcase(ident_digest, ident_schema):
     return (ident_digest, ident_schema)
@@ -48,7 +65,40 @@ def test_serialize_deserialize_array(array_testcase):
 
     raw = _serialize_arr(array_testcase)
     res = _deserialize_arr(raw)
-    assert_equal(array_testcase, res)
+    assert_array_equal(array_testcase, res)
+
+
+def test_serialize_deserialize_str(str_testcase):
+    from hangar.remote.chunks import _serialize_str, _deserialize_str
+    raw = _serialize_str(str_testcase)
+    res = _deserialize_str(raw)
+    assert res == str_testcase
+
+
+def test_serialize_deserialize_bytes(bytes_testcase):
+    from hangar.remote.chunks import _serialize_bytes, _deserialize_bytes
+    raw = _serialize_bytes(bytes_testcase)
+    res = _deserialize_bytes(raw)
+    assert bytes_testcase == res
+
+
+@pytest.mark.parametrize('expected_dtype_code,data', [
+    (0, np.array([0, 1, 2, 3, 4])),
+    (2, 'i am string'),
+    (3, b'i am bytes')
+])
+def test_serialize_deserialize_data(expected_dtype_code, data):
+    from hangar.remote.chunks import serialize_data, deserialize_data
+
+    dtcode, raw = serialize_data(data)
+    res = deserialize_data(dtype_code=dtcode, raw_data=raw)
+    assert dtcode == expected_dtype_code
+    if isinstance(res, np.ndarray):
+        assert_array_equal(data, res)
+    elif isinstance(res, (str, bytes)):
+        assert data == res
+    else:
+        raise TypeError(data)
 
 
 def test_serialize_deserialize_ident(ident_testcase):
@@ -73,7 +123,7 @@ def test_serialize_deserialize_record(array_testcase, ident_testcase):
     raw = serialize_record(array_testcase, digest, schema)
     res = deserialize_record(raw)
     assert isinstance(res, DataRecord)
-    assert_equal(res.array, array_testcase)
+    assert_array_equal(res.data, array_testcase)
     assert res.digest == digest
     assert res.schema == schema
 
@@ -93,8 +143,8 @@ def test_serialize_deserialize_record_pack(ident_testcase, nrecords):
         for dtype in param_dtypes:
             arr = 200 * np.random.random_sample(shape) + 100
             arr = arr.astype(dtype)
-            digest = f'digest{str(idx)*len(digest)}'
-            schema = f'schema{str(idx)*len(schema)}'
+            digest = f'digest{str(idx) + str(digest)}'
+            schema = f'schema{str(idx) + str(schema)}'
             idx += 1
 
             ArrList.append((arr, digest, schema))
@@ -108,7 +158,7 @@ def test_serialize_deserialize_record_pack(ident_testcase, nrecords):
     for rawres, origRec in zip(reslist, ArrList):
         resRec = deserialize_record(rawres)
         assert isinstance(resRec, DataRecord)
-        assert_equal(resRec.array, origRec[0])
+        assert_array_equal(resRec.data, origRec[0])
         assert resRec.digest == origRec[1]
         assert resRec.schema == origRec[2]
 
@@ -151,8 +201,8 @@ def test_serialize_deserialize_ident_only_record_pack(ident_testcase, nrecords):
     IdentList, RawList = [], []
     digest, schema = ident_testcase
     for idx in range(nrecords):
-        digest = f'digest{str(idx)*len(digest)}'
-        schema = f'schema{str(idx)*len(schema)}'
+        digest = f'digest{str(idx) + str(digest)}'
+        schema = f'schema{str(idx) + str(schema)}'
 
         IdentList.append((digest, schema))
         RawList.append(serialize_ident(digest, schema))
@@ -181,7 +231,7 @@ def test_serialize_deserialize_ident_only_digest_only_record_pack(ident_testcase
     IdentList, RawList = [], []
     digest, schema = ident_testcase
     for idx in range(nrecords):
-        digest = f'digest{str(idx)*len(digest)}'
+        digest = f'digest{str(idx)+str(digest)}'
         schema = f''
 
         IdentList.append((digest, schema))
@@ -212,7 +262,7 @@ def test_serialize_deserialize_ident_only_schema_only_record_pack(ident_testcase
     digest, schema = ident_testcase
     for idx in range(nrecords):
         digest = f''
-        schema = f'schema{str(idx)*len(schema)}'
+        schema = f'schema{str(idx)+str(schema)}'
 
         IdentList.append((digest, schema))
         RawList.append(serialize_ident(digest, schema))

--- a/tests/test_remote_serialize.py
+++ b/tests/test_remote_serialize.py
@@ -43,23 +43,23 @@ def ident_testcase(ident_digest, ident_schema):
 
 
 def test_serialize_deserialize_array(array_testcase):
-    from hangar.remote.chunks import serialize_arr
-    from hangar.remote.chunks import deserialize_arr
+    from hangar.remote.chunks import _serialize_arr
+    from hangar.remote.chunks import _deserialize_arr
 
-    raw = serialize_arr(array_testcase)
-    res = deserialize_arr(raw)
+    raw = _serialize_arr(array_testcase)
+    res = _deserialize_arr(raw)
     assert_equal(array_testcase, res)
 
 
 def test_serialize_deserialize_ident(ident_testcase):
     from hangar.remote.chunks import serialize_ident
     from hangar.remote.chunks import deserialize_ident
-    from hangar.remote.chunks import ArrayIdent
+    from hangar.remote.chunks import DataIdent
 
     digest, schema = ident_testcase
     raw = serialize_ident(digest, schema)
     res = deserialize_ident(raw)
-    assert isinstance(res, ArrayIdent)
+    assert isinstance(res, DataIdent)
     assert res.digest == digest
     assert res.schema == schema
 
@@ -67,12 +67,12 @@ def test_serialize_deserialize_ident(ident_testcase):
 def test_serialize_deserialize_record(array_testcase, ident_testcase):
     from hangar.remote.chunks import serialize_record
     from hangar.remote.chunks import deserialize_record
-    from hangar.remote.chunks import ArrayRecord
+    from hangar.remote.chunks import DataRecord
 
     digest, schema = ident_testcase
     raw = serialize_record(array_testcase, digest, schema)
     res = deserialize_record(raw)
-    assert isinstance(res, ArrayRecord)
+    assert isinstance(res, DataRecord)
     assert_equal(res.array, array_testcase)
     assert res.digest == digest
     assert res.schema == schema
@@ -84,7 +84,7 @@ def test_serialize_deserialize_record_pack(ident_testcase, nrecords):
     from hangar.remote.chunks import serialize_record_pack
     from hangar.remote.chunks import deserialize_record
     from hangar.remote.chunks import deserialize_record_pack
-    from hangar.remote.chunks import ArrayRecord
+    from hangar.remote.chunks import DataRecord
 
     idx = 0
     ArrList, RecList = [], []
@@ -107,7 +107,7 @@ def test_serialize_deserialize_record_pack(ident_testcase, nrecords):
 
     for rawres, origRec in zip(reslist, ArrList):
         resRec = deserialize_record(rawres)
-        assert isinstance(resRec, ArrayRecord)
+        assert isinstance(resRec, DataRecord)
         assert_equal(resRec.array, origRec[0])
         assert resRec.digest == origRec[1]
         assert resRec.schema == origRec[2]
@@ -116,12 +116,12 @@ def test_serialize_deserialize_record_pack(ident_testcase, nrecords):
 def test_serialize_deserialize_ident_digest_field_only(ident_testcase):
     from hangar.remote.chunks import serialize_ident
     from hangar.remote.chunks import deserialize_ident
-    from hangar.remote.chunks import ArrayIdent
+    from hangar.remote.chunks import DataIdent
 
     digest, schema = ident_testcase
     raw = serialize_ident(digest, '')
     res = deserialize_ident(raw)
-    assert isinstance(res, ArrayIdent)
+    assert isinstance(res, DataIdent)
     assert res.digest == digest
     assert res.schema == ''
 
@@ -129,12 +129,12 @@ def test_serialize_deserialize_ident_digest_field_only(ident_testcase):
 def test_serialize_deserialize_ident_schema_field_only(ident_testcase):
     from hangar.remote.chunks import serialize_ident
     from hangar.remote.chunks import deserialize_ident
-    from hangar.remote.chunks import ArrayIdent
+    from hangar.remote.chunks import DataIdent
 
     digest, schema = ident_testcase
     raw = serialize_ident('', schema)
     res = deserialize_ident(raw)
-    assert isinstance(res, ArrayIdent)
+    assert isinstance(res, DataIdent)
     assert res.digest == ''
     assert res.schema == schema
 
@@ -145,7 +145,7 @@ def test_serialize_deserialize_ident_only_record_pack(ident_testcase, nrecords):
     from hangar.remote.chunks import deserialize_ident
     from hangar.remote.chunks import serialize_record_pack
     from hangar.remote.chunks import deserialize_record_pack
-    from hangar.remote.chunks import ArrayIdent
+    from hangar.remote.chunks import DataIdent
 
     idx = 0
     IdentList, RawList = [], []
@@ -164,7 +164,7 @@ def test_serialize_deserialize_ident_only_record_pack(ident_testcase, nrecords):
 
     for raw, origIdent in zip(unpacked_raw, IdentList):
         resIdent = deserialize_ident(raw)
-        assert isinstance(resIdent, ArrayIdent)
+        assert isinstance(resIdent, DataIdent)
         assert resIdent.digest == origIdent[0]
         assert resIdent.schema == origIdent[1]
 
@@ -175,7 +175,7 @@ def test_serialize_deserialize_ident_only_digest_only_record_pack(ident_testcase
     from hangar.remote.chunks import deserialize_ident
     from hangar.remote.chunks import serialize_record_pack
     from hangar.remote.chunks import deserialize_record_pack
-    from hangar.remote.chunks import ArrayIdent
+    from hangar.remote.chunks import DataIdent
 
     idx = 0
     IdentList, RawList = [], []
@@ -194,7 +194,7 @@ def test_serialize_deserialize_ident_only_digest_only_record_pack(ident_testcase
 
     for raw, origIdent in zip(unpacked_raw, IdentList):
         resIdent = deserialize_ident(raw)
-        assert isinstance(resIdent, ArrayIdent)
+        assert isinstance(resIdent, DataIdent)
         assert resIdent.digest == origIdent[0]
         assert resIdent.schema == origIdent[1]
 
@@ -205,7 +205,7 @@ def test_serialize_deserialize_ident_only_schema_only_record_pack(ident_testcase
     from hangar.remote.chunks import deserialize_ident
     from hangar.remote.chunks import serialize_record_pack
     from hangar.remote.chunks import deserialize_record_pack
-    from hangar.remote.chunks import ArrayIdent
+    from hangar.remote.chunks import DataIdent
 
     idx = 0
     IdentList, RawList = [], []
@@ -224,6 +224,6 @@ def test_serialize_deserialize_ident_only_schema_only_record_pack(ident_testcase
 
     for raw, origIdent in zip(unpacked_raw, IdentList):
         resIdent = deserialize_ident(raw)
-        assert isinstance(resIdent, ArrayIdent)
+        assert isinstance(resIdent, DataIdent)
         assert resIdent.digest == origIdent[0]
         assert resIdent.schema == origIdent[1]

--- a/tests/test_remotes.py
+++ b/tests/test_remotes.py
@@ -567,55 +567,8 @@ def test_push_clone_three_way_merge(server_instance, repo_2_br_no_conf, managed_
     newRepo._env._close_environments()
 
 
-# ---------------------------- fixture func servers ---------------------------
-
-
-@pytest.fixture()
-def server_instance_nbytes_limit(monkeypatch, managed_tmpdir, worker_id, mocker):
-    from hangar.remote.server import serve
-
-    address = f'localhost:{randint(50000, 59999)}'
-    base_tmpdir = pjoin(managed_tmpdir, f'{worker_id[-1]}')
-    mkdir(base_tmpdir)
-    server, hangserver, _ = serve(base_tmpdir, overwrite=True, channel_address=address)
-    hangserver.CFG['SERVER_GRPC']['fetch_max_nbytes'] = '500000'
-    hangserver.CFG['CLIENT_GRPC']['push_max_nbytes'] = '500000'
-    server.start()
-    yield address
-
-    hangserver.env._close_environments()
-    server.stop(0.05)
-    time.sleep(0.1)
-    if platform.system() == 'Windows':
-        # time for open file handles to close before tmp dir can be removed.
-        time.sleep(0.1)
-
-
-@pytest.fixture()
-def server_instance_push_restricted(managed_tmpdir, worker_id):
-    from hangar.remote.server import serve
-
-    address = f'localhost:{randint(50000, 59999)}'
-    base_tmpdir = pjoin(managed_tmpdir, f'{worker_id[-1]}')
-    mkdir(base_tmpdir)
-    server, hangserver, _ = serve(base_tmpdir,
-                                  overwrite=True,
-                                  channel_address=address,
-                                  restrict_push=True,
-                                  username='right_username',
-                                  password='right_password')
-    server.start()
-    yield address
-
-    hangserver.env._close_environments()
-    server.stop(0.05)
-    time.sleep(0.1)
-    if platform.system() == 'Windows':
-        # time for open file handles to close before tmp dir can be removed.
-        time.sleep(0.1)
-
-
 # -----------------------------------------------------------------------------
+
 
 @pytest.mark.skip(reason='unknown test failures intermitently')
 def test_push_clone_digests_exceeding_server_nbyte_limit(mocker, server_instance_nbytes_limit, repo, managed_tmpdir):

--- a/tests/test_repo_integrity_verification.py
+++ b/tests/test_repo_integrity_verification.py
@@ -8,6 +8,7 @@ def diverse_repo(repo):
     co = repo.checkout(write=True)
     co.add_ndarray_column('test', prototype=np.arange(10))
     co.add_str_column('test_meta')
+    co.add_bytes_column('test_bytes')
     co.columns['test'][0] = np.arange(10)
     co.columns['test'][1] = np.arange(10) + 1
     co.columns['test'][2] = np.arange(10) + 2
@@ -15,6 +16,7 @@ def diverse_repo(repo):
     co.columns['test'][4] = np.arange(10) + 4
     co['test_meta']['hi'] = 'foo'
     co['test_meta']['aea'] = 'eeae'
+    co['test_bytes']['lol'] = b'foo bytes'
     co.commit('hello world')
 
     sample_trimg = np.arange(50).reshape(5, 10).astype(np.uint8)
@@ -46,6 +48,7 @@ def diverse_repo(repo):
     dset_vimgs[1] = sample_vimg + 1
     dset_vimgs[2] = sample_vimg + 2
     co['test_meta']['second'] = 'on master now'
+    co['test_bytes']['second'] = b'on master now'
     co.commit('second on master')
     co.close()
 
@@ -53,6 +56,7 @@ def diverse_repo(repo):
     repo.create_branch('newbranch', base_commit=base)
     co = repo.checkout(write=True, branch='master')
     co['test_meta']['newmeta'] = 'wow'
+    co['test_bytes']['newbytes'] = b'new bytesdata'
     co.commit('on master after merge')
     co.close()
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -799,7 +799,7 @@ class TestVersion:
         assert not op(Version(left), Version(right))
 
     @pytest.mark.parametrize(("op", "expected"), [("eq", False), ("ne", True)])
-    def test_compare_other(self, op, expected):
+    def test_compare_other(self, monkeypatch, op, expected):
         other = pretend.stub(**{"__{0}__".format(op): lambda other: NotImplemented})
 
         assert getattr(operator, op)(Version("1"), other) is expected

--- a/tests/typesystem/test_pybytes_typesystem.py
+++ b/tests/typesystem/test_pybytes_typesystem.py
@@ -1,9 +1,7 @@
 import pytest
 import numpy as np
-from random import randint, choices
 
-
-from hangar.typesystem import StringVariableShape
+from hangar.typesystem import BytesVariableShape
 
 
 class TestInvalidValues:
@@ -11,31 +9,31 @@ class TestInvalidValues:
     @pytest.mark.parametrize('coltype', ['ndarray', np.ndarray, 32, {'foo': 'bar'}, ascii])
     def test_column_type_must_be_str(self, coltype):
         with pytest.raises(ValueError):
-            StringVariableShape(dtype=str, column_layout='flat', column_type=coltype)
+            BytesVariableShape(dtype=bytes, column_layout='flat', column_type=coltype)
 
     @pytest.mark.parametrize('collayout', ['f', 'n', None, 32, {'foo': 'bar'}, ascii])
     def test_column_layout_must_be_valid_value(self, collayout):
         with pytest.raises(ValueError):
-            StringVariableShape(dtype=str, column_layout=collayout)
+            BytesVariableShape(dtype=bytes, column_layout=collayout)
 
-    @pytest.mark.parametrize('backend', ['00', 24, {'30': '30'}, ('30',), ['50',], ascii, 'None'])
+    @pytest.mark.parametrize('backend', ['00', 24, {'31': '31'}, ('31',), ['50', ], ascii, 'None'])
     def test_variable_shape_backend_code_valid_value(self, backend):
         with pytest.raises(ValueError):
-            StringVariableShape(dtype=str, column_layout='flat', backend=backend)
+            BytesVariableShape(dtype=bytes, column_layout='flat', backend=backend)
 
     @pytest.mark.parametrize('opts', ['val', [], (), [('k', 'v')], 10, ({'k': 'v'},), ascii])
     def test_backend_options_must_be_dict_or_nonetype(self, opts):
         with pytest.raises(TypeError):
-            StringVariableShape(dtype=str, column_layout='flat', backend='30', backend_options=opts)
+            BytesVariableShape(dtype=bytes, column_layout='flat', backend='31', backend_options=opts)
 
     def test_backend_must_be_specified_if_backend_options_provided(self):
         with pytest.raises(ValueError):
-            StringVariableShape(dtype=str, column_layout='flat', backend_options={})
+            BytesVariableShape(dtype=bytes, column_layout='flat', backend_options={})
 
     @pytest.mark.parametrize('schema_type', ['fixed_shape', True, 'str', np.uint8, 3, ascii])
     def test_variable_shape_must_have_variable_shape_schema_type(self, schema_type):
         with pytest.raises(ValueError):
-            StringVariableShape(dtype=str, column_layout='flat', schema_type=schema_type)
+            BytesVariableShape(dtype=bytes, column_layout='flat', schema_type=schema_type)
 
 
 # ----------------------- Fixtures for Valid Schema ---------------------------
@@ -46,7 +44,7 @@ def column_layout(request):
     return request.param
 
 
-@pytest.fixture(params=['30'], scope='class')
+@pytest.fixture(params=['31'], scope='class')
 def backend(request):
     return request.param
 
@@ -58,30 +56,26 @@ def backend_options(request):
 
 @pytest.fixture(scope='class')
 def valid_schema(column_layout, backend, backend_options):
-    schema = StringVariableShape(
-        dtype=str, column_layout=column_layout, backend=backend, backend_options=backend_options)
+    schema = BytesVariableShape(
+        dtype=bytes, column_layout=column_layout, backend=backend, backend_options=backend_options)
     return schema
 
 
 class TestValidSchema:
 
     @pytest.mark.parametrize('data', [
-        'hello', 'world how are you?', '\n what\'s up',
-        'loob!', 'a\xac\u1234\u20ac\U00008000', 'lol'
+        b'hello', b'world how are you?', b'\n what\'s up',
+        b'loob!', b'lol',
+        (b"\x80\x04\x95'\x00\x00\x00\x00\x00\x00\x00\x8c\x08__main__"
+         b"\x94\x8c\x07testobj\x94\x93\x94)\x81\x94}\x94\x8c\x04name\x94Nsb.")
     ])
     def test_valid_data(self, valid_schema, data):
         res = valid_schema.verify_data_compatible(data)
         assert res.compatible is True
         assert res.reason == ''
 
-    @pytest.mark.parametrize('data', [chr(24523), chr(253), chr(6222)])
-    def test_large_unicode_codepoints_strings_compatible(self, valid_schema, data):
-        res = valid_schema.verify_data_compatible(data)
-        assert res.compatible is True
-        assert res.reason == ''
-
-    def test_strings_over_2MB_size_not_allowed(self, valid_schema):
-        data = ''.join(['a' for _ in range(2_000_001)])
+    def test_data_over_2MB_size_not_allowed(self, valid_schema):
+        data = ''.join(['a' for _ in range(2_000_001)]).encode()
         res = valid_schema.verify_data_compatible(data)
         assert res.compatible is False
 

--- a/tox.ini
+++ b/tox.ini
@@ -26,10 +26,7 @@ TESTML =
 deps =
     Cython
     py{36,37,38}: pytest != 5.3.3
-        pytest-travis-fold
         pytest-xdist
-        pytest-mock
-        pytest-sugar
         hypothesis[numpy]
         pretend
     covyes: pytest-cov
@@ -98,7 +95,7 @@ commands =
 # ------------------- mypy ----------------------
 
 [testenv:mypy]
-basepython = {env:TOXPYTHON:python3.7}
+basepython = {env:TOXPYTHON:python3.8}
 skip_install = False
 commands =
     {posargs:mypy --config-file mypy.ini src/hangar}


### PR DESCRIPTION
## Motivation and Context
#### _Why is this change required? What problem does it solve?:_

At the request of @elistevens (and other) I have added the ability to create a column which contains arbitrary `bytes` typed data. No inference is applied to the content (which would traditionally be used to select suitable storage backends), nor is any type of compression applied by the LMDB_31 backend. 

Each sample can be at most 2 MB in size. This limit is imposed somewhat arbitrarily, but is set rather low to encourage this `column_dtype` to only be used for storage of informational metadata.

Additionally, we have lifted the `ascii-only` restriction for data placed in the `str` type column. This was a legacy restriction which is unneeded now that highly configurable type validation is applied automatically to each column schema. 

This PR is ready for immediate review (with the exception of updating sphinx / API documentation). 

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Documentation update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Is this PR ready for review, or a work in progress?
- [x] Ready for review
- [ ] Work in progress

## How Has This Been Tested?
Put an `x` in the boxes that apply:
- [ ] Current tests cover modifications made
- [x] New tests have been added to the test suite
- [ ] Modifications were made to existing tests to support these changes
- [ ] Tests may be needed, but they are not included when the PR was proposed
- [ ] I don't know. Help!

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.rst)** document.
- [x] I have signed (or will sign when prompted) the tensorwork CLA.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
